### PR TITLE
Add controllerConfig.serviceServiceCert, for deploying router on OSE >= 1.3.0

### DIFF
--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -23,6 +23,11 @@ assetConfig:
 controllerLeaseTTL: <%= node['cookbook-openshift3']['openshift_master_controller_lease_ttl'] %>
 <% end -%>
 controllers: '*'
+controllerConfig:
+  serviceServingCert:
+    signer:
+      certFile: service-signer.crt
+      keyFile: service-signer.key
 corsAllowedOrigins:
 <%- @erb_corsAllowedOrigins.each do |origin| -%>
   - <%= origin %>


### PR DESCRIPTION
This PR configures the master to declare a `controllerConfig.serviceServiceCert` section.
Without it, the router won't deploy out of the box Openshift 1.3.0 and OSE 3.3.

See https://github.com/openshift/openshift-ansible/issues/2345