### PR TITLE
Pin the OSEv3 RPM version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ else
   default['cookbook-openshift3']['master_etcd_cert_prefix'] = ''
 end
 
+default['cookbook-openshift3']['ose_version'] = nil
 default['cookbook-openshift3']['deploy_containerized'] = false
 default['cookbook-openshift3']['deploy_example'] = false
 default['cookbook-openshift3']['deploy_dnsmasq'] = false

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -20,7 +20,11 @@ if node['cookbook-openshift3']['openshift_HA']
 end
 
 if master_servers.find { |server_master| server_master['fqdn'] == node['fqdn'] }
-  package node['cookbook-openshift3']['openshift_service_type'] unless node['cookbook-openshift3']['deploy_containerized']
+  package node['cookbook-openshift3']['openshift_service_type'] do
+    version node['cookbook-openshift3'] ['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
+    not_if { node['cookbook-openshift3']['deploy_containerized'] }
+  end
+
 
   package 'httpd' do
     notifies :run, 'ruby_block[Change HTTPD port xfer]', :immediately

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -152,6 +152,7 @@ end
 
 package "#{node['cookbook-openshift3']['openshift_service_type']}-master" do
   action :install
+  version node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
   notifies :reload, 'service[daemon-reload]', :immediately
 end
 

--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -43,7 +43,7 @@ end
 
 package "#{node['cookbook-openshift3']['openshift_service_type']}-master" do
   action :install
-  vesion node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
+  version node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
   notifies :reload, 'service[daemon-reload]', :immediately
   not_if { node['cookbook-openshift3']['deploy_containerized'] }
 end

--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -43,6 +43,7 @@ end
 
 package "#{node['cookbook-openshift3']['openshift_service_type']}-master" do
   action :install
+  vesion node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
   notifies :reload, 'service[daemon-reload]', :immediately
   not_if { node['cookbook-openshift3']['deploy_containerized'] }
 end

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -70,6 +70,7 @@ if node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }
 
   package "#{node['cookbook-openshift3']['openshift_service_type']}-sdn-ovs" do
     action :install
+    version node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
     only_if { node['cookbook-openshift3']['openshift_common_use_openshift_sdn'] == true }
     not_if { node['cookbook-openshift3']['deploy_containerized'] }
   end

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -64,6 +64,7 @@ if node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }
 
   package "#{node['cookbook-openshift3']['openshift_service_type']}-node" do
     action :install
+    version node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
     not_if { node['cookbook-openshift3']['deploy_containerized'] }
   end
 


### PR DESCRIPTION
We would like an option to hold the version of the atomic host RPM.  This would ensure stability while building out nodes within a cluster.