### PR TITLE
Bugfix: default to enterprise before ternary operator

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ else
 end
 
 default['cookbook-openshift3']['ose_version'] = nil
+default['cookbook-openshift3']['openshift_deployment_type'] = 'enterprise'
 default['cookbook-openshift3']['ose_major_version'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? '3.3' : '1.3'
 default['cookbook-openshift3']['deploy_containerized'] = false
 default['cookbook-openshift3']['deploy_example'] = false
@@ -46,7 +47,6 @@ default['cookbook-openshift3']['enabled_firewall_rules_master_cluster'] = %w(fir
 default['cookbook-openshift3']['enabled_firewall_rules_node'] = %w(firewall_node)
 default['cookbook-openshift3']['enabled_firewall_additional_rules_node'] = []
 default['cookbook-openshift3']['enabled_firewall_rules_etcd'] = %w(firewall_etcd)
-default['cookbook-openshift3']['openshift_deployment_type'] = 'enterprise'
 default['cookbook-openshift3']['openshift_service_type'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'atomic-openshift' : 'origin'
 default['cookbook-openshift3']['yum_repositories'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]
 default['cookbook-openshift3']['openshift_data_dir'] = '/var/lib/origin'


### PR DESCRIPTION
Default behaviour was:

major version: 1.3
deployment type: enterprise

because at the time of setting the major version deployment type was unset. I assume this wasn't the intended default.