### PR TITLE
Enable MatchInterPodAffinity scheduler predicate

### DIFF
--- a/templates/default/scheduler.json.erb
+++ b/templates/default/scheduler.json.erb
@@ -6,6 +6,7 @@
     {"name": "PodFitsResources"},
     {"name": "PodFitsPorts"},
     {"name": "NoDiskConflict"},
+    {"name": "MatchInterPodAffinity"},
     {"name": "Region", "argument": {"serviceAffinity" : {"labels" : ["region"]}}}
   ],"priorities": [
     {"name": "LeastRequestedPriority", "weight": 1},


### PR DESCRIPTION
This PR enables the MatchInterPodAffinity scheduler predicate, used to implement pod anti-affinity, as exampled in here: https://docs.openshift.com/container-platform/3.3/admin_guide/manage_nodes.html#pod-anti-affinity . As far as I know this is openshift 1.3.x feature, it probably does not work with earlier versions.

I am embarrassed, because I don't know which option is best to enable this feature without forcing it on other users of this cookbook:
 - should we enable it by default (the most simple solution, what I did in this PR)
 - should we add an attribute to enable the predicate or not (but then why not make the whole content of the file customizable with attributes)
 - should we add 2 'cookbook' and 'source' attributes with default value to 'cookbook-openshift3' and 'scheduler.json.erb' so that wrapper cookbooks can easily override the whole template?
Feel free to discuss before merging.

Note that I base this PR on version v0.10.18 because something broke in v0.10.19 that prevents me from provisioning master and node in the same chef run.