### PR TITLE
Fix schedulability and node-labelling guards

### DIFF
--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -86,8 +86,8 @@ node_servers.each do |nodes|
     )
     cwd Chef::Config[:file_cache_path]
     only_if do
-      master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] }
-      !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
+      master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } &&
+        !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
     end
   end
 
@@ -98,8 +98,8 @@ node_servers.each do |nodes|
     )
     cwd Chef::Config[:file_cache_path]
     not_if do
-      master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] }
-      Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
+      master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } ||
+        Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
     end
   end
 
@@ -110,8 +110,8 @@ node_servers.each do |nodes|
     )
     cwd Chef::Config[:file_cache_path]
     only_if do
-      nodes.key?('labels')
-      !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
+      nodes.key?('labels') &&
+        !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
     end
   end
 end


### PR DESCRIPTION
Hi @IshentRas ,

This PR fixes the guards that were recently added in recipe[master_config_post] to prevent setting node schedulability or labels when the node is declared in node_servers but is not online yet.

The syntax:

```ruby
not_if do
  condition1
  condition2
end
```

Should not be valid in Ruby (because the block will evaluate condition1 but ignore its return value).
I have fixed it to the following syntax:

```ruby
not_if do
  condition1 &&
    condition2
end
```