### PR TITLE
Add support for configuring docker log driver using attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ Override Attributes
 }
 ```
 
+* `node['cookbook-openshift3']['docker_log_driver'`
+
+Set to `'json-file'` (default), `'journald'` or any other supported [docker log driver](https://docs.docker.com/engine/admin/logging/overview/).
+
 * `node['cookbook-openshift3']['docker_log_options']`
+
+Assuming `node['cookbook-openshift3']['docker_log_driver']` is `'json-file'` (the default):
 
 ```json
 {
@@ -83,6 +89,9 @@ Override Attributes
  "max-file": "3"
 }
 ```
+
+Any option can be set, as long as they are supported by the current [docker log driver](https://docs.docker.com/engine/admin/logging/overview/).
+
 
 * `node['cookbook-openshift3']['openshift_master_named_certificates']`
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,8 @@ default['cookbook-openshift3']['deploy_example_xpaas-streams'] = false
 default['cookbook-openshift3']['deploy_example_xpaas-templates'] = false
 
 default['cookbook-openshift3']['docker_version'] = nil
-default['cookbook-openshift3']['docker_log_options'] = nil
+default['cookbook-openshift3']['docker_log_driver'] = 'json-file'
+default['cookbook-openshift3']['docker_log_options'] = {}
 default['cookbook-openshift3']['install_method'] = 'yum'
 default['cookbook-openshift3']['httpd_xfer_port'] = '9999'
 default['cookbook-openshift3']['core_packages'] = %w(libselinux-python wget vim-enhanced net-tools bind-utils git bash-completion bash-completion dnsmasq)

--- a/templates/default/service_docker.sysconfig.erb
+++ b/templates/default/service_docker.sysconfig.erb
@@ -1,8 +1,8 @@
 # /etc/sysconfig/docker
 
 # Modify these options if you want to change the way the docker daemon runs
-<% if node['cookbook-openshift3']['docker_log_options'] %>
-OPTIONS='--insecure-registry=<%= node['cookbook-openshift3']['openshift_docker_insecure_registries'].join(' --insecure-registry=') %> --selinux-enabled --log-driver=json-file --log-opt max-size=<%= node['cookbook-openshift3']['docker_log_options']['max-size'] %> --log-opt max-file=<%= node['cookbook-openshift3']['docker_log_options']['max-file'] %>'
+<% unless node['cookbook-openshift3']['docker_log_driver'] == 'json-file' && node['cookbook-openshift3']['docker_log_options'].empty? %>
+OPTIONS='--insecure-registry=<%= node['cookbook-openshift3']['openshift_docker_insecure_registries'].join(' --insecure-registry=') %> --selinux-enabled --log-driver=<%= node['cookbook-openshift3']['docker_log_driver'] %><%= node['cookbook-openshift3']['docker_log_options'].map { |opt, value| " --log-opt #{opt}=#{value}" }.sort.join('') %>'
 <% else -%>
 OPTIONS='--insecure-registry=<%= node['cookbook-openshift3']['openshift_docker_insecure_registries'].join(' --insecure-registry=') %> --selinux-enabled'
 <% end -%>


### PR DESCRIPTION
This simple PR enables to configure a log-driver different than `json-file`.

As system administrator, I want openshift docker component to log to journald,
so that I can efficiently load those logs into the openshift logging system.

This PR should be backward-compatible with the existing attributes.