### PR TITLE
Default ipaddress in etcd attributes is now the openshift common ip

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -183,8 +183,8 @@ default['cookbook-openshift3']['etcd_default_days'] = '365'
 default['cookbook-openshift3']['etcd_client_port'] = '2379'
 default['cookbook-openshift3']['etcd_peer_port'] = '2380'
 
-default['cookbook-openshift3']['etcd_initial_advertise_peer_urls'] = "https://#{node['ipaddress']}:#{node['cookbook-openshift3']['etcd_peer_port']}"
-default['cookbook-openshift3']['etcd_listen_peer_urls'] = "https://#{node['ipaddress']}:#{node['cookbook-openshift3']['etcd_peer_port']}"
-default['cookbook-openshift3']['etcd_listen_client_urls'] = "https://#{node['ipaddress']}:#{node['cookbook-openshift3']['etcd_client_port']}"
-default['cookbook-openshift3']['etcd_advertise_client_urls'] = "https://#{node['ipaddress']}:#{node['cookbook-openshift3']['etcd_client_port']}"
-default['cookbook-openshift3']['etcd_listen_client_urls'] = "https://#{node['ipaddress']}:#{node['cookbook-openshift3']['etcd_client_port']}"
+default['cookbook-openshift3']['etcd_initial_advertise_peer_urls'] = "https://#{node['cookbook-openshift3']['openshift_common_ip']}:#{node['cookbook-openshift3']['etcd_peer_port']}"
+default['cookbook-openshift3']['etcd_listen_peer_urls'] = "https://#{node['cookbook-openshift3']['openshift_common_ip']}:#{node['cookbook-openshift3']['etcd_peer_port']}"
+default['cookbook-openshift3']['etcd_listen_client_urls'] = "https://#{node['cookbook-openshift3']['openshift_common_ip']}:#{node['cookbook-openshift3']['etcd_client_port']}"
+default['cookbook-openshift3']['etcd_advertise_client_urls'] = "https://#{node['cookbook-openshift3']['openshift_common_ip']}:#{node['cookbook-openshift3']['etcd_client_port']}"
+default['cookbook-openshift3']['etcd_listen_client_urls'] = "https://#{node['cookbook-openshift3']['openshift_common_ip']}:#{node['cookbook-openshift3']['etcd_client_port']}"


### PR DESCRIPTION
This PR is controversial, I would like to have your thoughts on it @IshentRas before merging.

In this PR, I set the default ipaddress used in etcd-related attributes to `node['cookbook-openshift3']['openshift_common_ip']` instead of `node['ipaddress']`.

Some context first: I develop my openshift3-based platform using a multi-VM Vagrant cluster. With Vagrant (Virtualbox provider), the first network interface of each VM is always of type NAT and has an ipaddress of `10.0.2.15`. This is of course unsuitable for multi-VM networking. As a consequence, my Vagrantfile declares for each VM a secondary network interface which is of host-only type and comes with a globally-unique static ipaddress. Then I configure my node_servers, master_servers, etcd_servers using those static ipaddresses.

Since I cannot rely on `node['ipaddress']` to work, I must configure every chef cookbook to note use the default `node['ipaddress']` but the host-only ipaddress instead. Specifically, when I work with this cookbook I have to include code like this in my Vagrantfile:

```ruby
  MASTER_NODES.each do |spec|
    config.vm.define spec['fqdn'], primary: true do |master|
      master.vm.hostname = spec['fqdn']
      master.vm.network 'private_network', ip: spec['ipaddress']
      # snip

      master.vm.provision 'chef_solo' do |chef|
        chef.json['cookbook-openshift3'] = {
          # snip
          'openshift_common_ip' => spec['ipaddress'],
          'etcd_initial_advertise_peer_urls' => "https://#{spec['ipaddress']}:2380",
          'etcd_listen_peer_urls' => "https://#{spec['ipaddress']}:2380",
          'etcd_listen_client_urls' => "https://#{spec['ipaddress']}:2379",
          'etcd_advertise_client_urls' => "https://#{spec['ipaddress']}:2379",
          # snip
        }

        # snip
    end
  end
```

Having both:
 - the `node['cookbook-openshift3']['etcd_servers']` attribute which contains explicit ipaddress
 - each etcd instance configuring itself implicitly to listen and advertise `node['ipaddress']`
At once is not DRY (attributes have to be specified in 2 places) and confusing (if only the etcd_servers attribute is configured as instructed in the README then the origin-master service will fail to start because it will try to contact etcd at the wrong ipaddress)

This is why I make this PR, so that etcd listens and advertise an ipaddress which is more likely to the be internal ipaddress on the cluster.