### PR TITLE
Fix etcd URLs in master.yaml when openshift_HA

### DIFF
--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -53,7 +53,7 @@ etcdClientInfo:
 <% if node['cookbook-openshift3']['openshift_HA'] %>
   urls:
 <%- @etcd_servers.each do |etcd_host| -%>
-    - https://<%= etcd_host['fqdn'] %>:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
+    - https://<%= etcd_host['ipaddress'] %>:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
 <%- end -%>
 <%- else -%>
   urls:


### PR DESCRIPTION
This PR comes as follow up to this comment https://github.com/IshentRas/cookbook-openshift3/pull/38#issuecomment-270134239 in #38 .

It ensures consistency between your last commit which made etcd listen to `etcd_server['ipaddress']` and the current openshift3 master configuration which reaches the etcd server by fqdn in the current code.

On a blank Vagrant VM, the fqdn gets a "free" /etc/hosts entry pointing to 127.0.0.1, so if I configure:

```ruby
ETCD_NODES = [
  { 'ipaddress' => '192.168.33.220', 'fqdn' => 'master' }
]
```

in my Vagrantfile then etcd will listen on '192.168.33.220' while the openshift master will look for etcd at fqdn 'master' which resolves to 127.0.0.1 in /etc/hosts.

I have checked that reaching the etcd by ipaddress does not break certificate verification.