### PR TITLE
Added kitchen inspec integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,62 @@
+---
+driver:
+  name: vagrant
+  customize:
+    cpus: 2
+    memory: 1024
+
+provisioner:
+  name: chef_zero
+  environments_path: test/environments
+  roles_path: test/roles
+  client_rb:
+    solo: false
+
+driver_config:
+  require_chef_omnibus: 12.17.44
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: centos-7.2
+    driver:
+      vm_hostname: origin-centos-72
+    attributes:
+      cookbook-openshift3:
+        # we override these because 10.0.2.15 is whitelisted in $no_proxy
+        openshift_common_public_hostname: 10.0.2.15
+        openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
+        ose_major_version: 1.3
+        docker_log_driver: journald
+        master_servers: &SERVERS
+         - ipaddress: 10.0.2.15
+           fqdn: origin-centos-72
+           labels: region=infra custom=label
+           schedulable: false
+        node_servers: *SERVERS
+
+suites:
+  - name: standalone
+    run_list:
+      - role[openshift3-base]
+    verifier:
+      inspec_tests:
+        - test/inspec/standalone
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        openshift_HA: false
+
+  - name: cluster-native
+    run_list:
+      - role[openshift3-base]
+    verifier:
+      inspec_tests:
+        - test/inspec/cluster-native
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        openshift_HA: true
+        openshift_cluster_name: test-cluster.domain.local
+        etcd_servers: *SERVERS

--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ Run list
 knife node run_list add NODE_NAME 'role[base]'
 ```
 
-Test (ORIGIN)
-==================
+Manual Integration Test (ORIGIN)
+================================
 
 There is a way to quickly test this cookbook. 
 You will need a CentOS 7.1+  with "Minimal" installation option and at least 10GB left on the Volume group. (Later used by Docker)
@@ -351,6 +351,24 @@ You will need a CentOS 7.1+  with "Minimal" installation option and at least 10G
 ```
 bash <(curl -s https://raw.githubusercontent.com/IshentRas/cookbook-openshift3/master/scripts/origin_deploy.sh)
 ```
+
+Automated Integration Tests (KITCHEN)
+=====================================
+
+This cookbook features [inspect](http://inspec.io/) integration tests,
+for both standalone and cluster-native (HA) variants.
+
+Assuming the latest [chef-dk](https://downloads.chef.io/chefdk) is installed,
+running the tests is as simple as:
+
+```sh
+kitchen converge
+# wait a few minutes to give openshift a chance to initialize before running the tests
+kitchen verify
+kitchen destroy
+```
+
+Check the `.kitchen.yml` file to get started.
 
 Development
 ==================

--- a/test/inspec/cluster-native/services_test.rb
+++ b/test/inspec/cluster-native/services_test.rb
@@ -1,0 +1,27 @@
+describe service('etcd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service('origin-master-api') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service('origin-master-controllers') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service('origin-master') do
+  it { should_not be_installed }
+end
+
+describe service('origin-node') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/inspec/shared/00_docker_test.rb
+++ b/test/inspec/shared/00_docker_test.rb
@@ -1,0 +1,11 @@
+describe service('docker') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+# It configures docker to use journald logging driver
+describe command('ps aux | grep docker | grep -v grep') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/log-driver=journald/) }
+end

--- a/test/inspec/shared/10_installation_test.rb
+++ b/test/inspec/shared/10_installation_test.rb
@@ -1,0 +1,9 @@
+# It installs `oc` command
+describe command('oc') do
+  it { should exist }
+end
+
+# It installs `oadm` command
+describe command('oadm') do
+  it { should exist }
+end

--- a/test/inspec/shared/11_functioning_openshift_test.rb
+++ b/test/inspec/shared/11_functioning_openshift_test.rb
@@ -1,0 +1,45 @@
+# It produces a working cluster
+describe command('oc status') do
+  its('exit_status') { should eq 0 }
+end
+
+# It initializes system services with plausible clusterIP (see role/openshift3-base.json)
+describe command('oc get service/kubernetes -n default --no-headers') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/172\.30\.0/) }
+end
+
+# It initializes a `default` namespace
+describe command('oc get namespace/default --no-headers') do
+  its('exit_status') { should eq 0 }
+end
+
+# logs the `system:admin` user
+describe command('oc whoami') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/system:admin/) }
+end
+
+# node has proper hostIP
+describe command('oc get hostsubnet/$HOSTNAME --template="{{.hostIP}}"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should eq '10.0.2.15' }
+end
+
+# node has proper hostsubnet (see role/openshift3-base.json)
+describe command('oc get hostsubnet/$HOSTNAME --template="{{.subnet}}"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should eq '10.128.0.0/23' }
+end
+
+# node is ready
+describe command('oc get node/$HOSTNAME --no-headers') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/Ready/) }
+end
+
+# node should not be schedulable unless stated in attributes
+describe command('oc get node/$HOSTNAME --no-headers') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/SchedulingDisabled/) }
+end

--- a/test/inspec/shared/20_feature_attribute_labels_test.rb
+++ b/test/inspec/shared/20_feature_attribute_labels_test.rb
@@ -1,0 +1,6 @@
+# node should have all labels configured in attributes
+describe command('oc get node/$HOSTNAME --template="{{.metadata.labels}}"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/region:infra/) }
+  its('stdout') { should match(/custom:label/) }
+end

--- a/test/inspec/standalone/services_test.rb
+++ b/test/inspec/standalone/services_test.rb
@@ -1,0 +1,23 @@
+describe service('etcd') do
+  it { should_not be_installed }
+end
+
+describe service('origin-master') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service('origin-master-api') do
+  it { should_not be_installed }
+end
+
+describe service('origin-master-controllers') do
+  it { should_not be_installed }
+end
+
+describe service('origin-node') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'cookbook-openshift3::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,0 @@
-require 'serverspec'
-
-set :backend, :exec

--- a/test/roles/openshift3-base.json
+++ b/test/roles/openshift3-base.json
@@ -1,0 +1,24 @@
+{
+  "name": "openshift3-base",
+  "description": "Openshift3 Common Base Role",
+  "json_class": "Chef::Role",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+    "cookbook-openshift3": {
+      "openshift_deployment_type": "origin",
+      "ose_major_version": "1.3",
+      "openshift_common_portal_net": "172.30.0.0/16",
+      "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
+      "openshift_master_sdn_host_subnet_length": 9,
+      "openshift_hosted_manage_router": false,
+      "openshift_hosted_manage_registry": false,
+      "deploy_example": false
+    }
+  },
+  "chef_type": "role",
+  "run_list": [
+    "recipe[cookbook-openshift3::default]"
+  ]
+}


### PR DESCRIPTION
As promised in https://github.com/IshentRas/cookbook-openshift3/issues/41#issuecomment-270339997, I have cleaned up and ported my own integration tests for this cookbook.

What is tested:
 - the basic openshift master/node deployment, in both standalone and cluster-native modes
 - the handling of the `labels` and `schedulable` node attributes.
 - docker logging configuration via `node['cookbook-openshift3']['docker_log_driver']`

What is not tested (yet):
 - hosted registry and router deployment (I don't use the feature yet)
 - example deployment (it would be trivial to add though)
 - storage provisioning feature
 - configuring htpasswd users (I will add the test when I port my wrapper cookbook to use the feature)

Feel free to play with the PR and leave your comments here.