### PR TITLE
Typo fix in openshift_deploy_registry LWRP

### DIFF
--- a/providers/openshift_deploy_registry.rb
+++ b/providers/openshift_deploy_registry.rb
@@ -18,7 +18,7 @@ action :create do
   end
 
   execute 'Deploy Hosted Registry' do
-    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm registry --selector=${selector_router} -n ${namespace_registry} --config=admin.kubeconfig"
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm registry --selector=${selector_registry} -n ${namespace_registry} --config=admin.kubeconfig"
     environment(
       'selector_registry' => node['cookbook-openshift3']['openshift_hosted_registry_selector'],
       'namespace_registry' => node['cookbook-openshift3']['openshift_hosted_registry_namespace']


### PR DESCRIPTION
This PR fixes a typo which results in the docker registry not being created with the expected node-selector parameter.

I spotted this one while porting to this cookbook my integration tests for hosted router and registry (coming soon in separate PR).