### PR TITLE
Refactor router-related resources to new openshift_deploy_router LWRP

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -208,6 +208,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * [openshift_delete_host](#openshift_delete_host)
 * [openshift_deploy_metrics](#openshift_deploy_metrics)
 * [openshift_deploy_registry](#openshift_deploy_registry)
+* [openshift_deploy_router](#openshift_deploy_router)
 * [openshift_redeploy_certificate](#openshift_redeploy_certificate)
 
 ## openshift_create_master
@@ -263,6 +264,16 @@ Installs/Configures Openshift 3.x (>= 3.2)
 ### Attribute Parameters
 
 - persistent_registry:
+
+## openshift_deploy_router
+
+### Actions
+
+- create:  Default action.
+
+### Attribute Parameters
+
+- none (for now)
 
 ## openshift_redeploy_certificate
 

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: cookbook-openshift3
+# Resources:: openshift_deploy_router
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+use_inline_resources
+provides :openshift_deploy_router if defined? provides
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
+    source 'file:///etc/origin/master/admin.kubeconfig'
+    mode '0644'
+  end
+
+  execute 'Deploy Hosted Router' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
+    environment(
+      'selector_router' => node['cookbook-openshift3']['openshift_hosted_router_selector'],
+      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
+    )
+    cwd Chef::Config[:file_cache_path]
+    only_if '[[ `oc get pod --selector=router=router --config=admin.kubeconfig | wc -l` -eq 0 ]]'
+  end
+
+  execute 'Auto Scale Router based on label' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} scale dc/router --replicas=${replica_number} -n ${namespace_router} --config=admin.kubeconfig"
+    environment(
+      'replica_number' => Mixlib::ShellOut.new("oc get node --no-headers --selector=#{node['cookbook-openshift3']['openshift_hosted_router_selector']} --config=#{Chef::Config[:file_cache_path]}/admin.kubeconfig | wc -l").run_command.stdout.strip,
+      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
+    )
+    cwd Chef::Config[:file_cache_path]
+    not_if '[[ `oc get pod --selector=router=router --config=admin.kubeconfig --no-headers | wc -l` -eq ${replica_number} ]]'
+  end
+
+  new_resource.updated_by_last_action(true)
+end

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -124,24 +124,9 @@ execute 'Wait up to 30s for nodes registration' do
   retry_delay 5
 end
 
-if node['cookbook-openshift3']['openshift_hosted_manage_router']
-  execute 'Deploy Hosted Router' do
-    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
-    environment(
-      'selector_router' => node['cookbook-openshift3']['openshift_hosted_router_selector'],
-      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
-    )
-    cwd Chef::Config[:file_cache_path]
-    only_if '[[ `oc get pod --selector=router=router --config=admin.kubeconfig | wc -l` -eq 0 ]]'
-  end
-  execute 'Auto Scale Router based on label' do
-    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} scale dc/router --replicas=${replica_number} -n ${namespace_router} --config=admin.kubeconfig"
-    environment(
-      'replica_number' => Mixlib::ShellOut.new("oc get node --no-headers --selector=#{node['cookbook-openshift3']['openshift_hosted_router_selector']} --config=#{Chef::Config[:file_cache_path]}/admin.kubeconfig | wc -l").run_command.stdout.strip,
-      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
-    )
-    cwd Chef::Config[:file_cache_path]
-    not_if '[[ `oc get pod --selector=router=router --config=admin.kubeconfig --no-headers | wc -l` -eq ${replica_number} ]]'
+openshift_deploy_router 'Deploy Router' do
+  only_if do
+    node['cookbook-openshift3']['openshift_hosted_manage_router']
   end
 end
 

--- a/resources/openshift_deploy_router.rb
+++ b/resources/openshift_deploy_router.rb
@@ -1,0 +1,12 @@
+#
+# Cookbook Name:: cookbook-openshift3
+# Resources:: openshift_deploy_router
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+provides :openshift_deploy_router
+resource_name :openshift_deploy_router
+
+actions :create
+
+default_action :create


### PR DESCRIPTION
This PR refactors the router-related execute resources in recipe[master_config_post] into a new `openshift_deploy_router` LWRP. Even if the new LWRP does not support any attributes for the moment, I think the pattern is consistent with the other addon LWRPs: `openshift_deploy_registry` and `openshift_deploy_metrics`,

It will also make it easier to configure the router in the future (eg. to specify custom default certificate) and will simplify my wrapper cookbooks.