### PR TITLE
Move registry persistent_volume_claim name to explicit LWRP attribute

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -262,7 +262,8 @@ Installs/Configures Openshift 3.x (>= 3.2)
 
 ### Attribute Parameters
 
-- persistent_registry:
+- persistent_registry: whether to enable registry persistence or not.
+- persistent_volume_claim_name: name of persist volume claim to use for registry storage
 
 ## openshift_redeploy_certificate
 

--- a/providers/openshift_deploy_registry.rb
+++ b/providers/openshift_deploy_registry.rb
@@ -101,7 +101,7 @@ action :create do
       command 'oc volume dc/docker-registry --add --overwrite -t persistentVolumeClaim --claim-name=${registry_claim} --name=registry-storage -n ${namespace_registry} --config=admin.kubeconfig'
       environment(
         'namespace_registry' => node['cookbook-openshift3']['openshift_hosted_registry_namespace'],
-        'registry_claim' => "#{node['cookbook-openshift3']['registry_persistent_volume']}-claim"
+        'registry_claim' => new_resource.persistent_volume_claim_name
       )
       cwd Chef::Config[:file_cache_path]
       not_if '[[ `oc get -o template dc/docker-registry --template={{.spec.template.spec.volumes}} -n ${namespace_registry} --config=admin.kubeconfig` =~ "${registry_claim}" ]]'

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -147,6 +147,7 @@ end
 
 openshift_deploy_registry 'Deploy Registry' do
   persistent_registry node['cookbook-openshift3']['registry_persistent_volume'].empty? ? false : true
+  persistent_volume_claim_name "#{node['cookbook-openshift3']['registry_persistent_volume']}-claim"
   only_if do
     node['cookbook-openshift3']['openshift_hosted_manage_registry']
   end

--- a/resources/openshift_deploy_registry.rb
+++ b/resources/openshift_deploy_registry.rb
@@ -12,3 +12,4 @@ actions :create
 default_action :create
 
 attribute :persistent_registry, kind_of: [TrueClass, FalseClass], required: true
+attribute :persistent_volume_claim_name, kind_of: [String], default: ''


### PR DESCRIPTION
Moved the hardcoded registry volume claim name in openshift_deploy_registry LWRP to an explicit attribute. Backward compatibility is preserved.