### PR TITLE
Support for Openshift Origin v1.4.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,12 +22,26 @@ platforms:
   - name: centos-7.2
     driver:
       vm_hostname: origin-centos-72
+
+suites:
+  - name: standalone
+    run_list:
+      - role[openshift3-base]
+    verifier:
+      inspec_tests:
+        - test/inspec/standalone
+        - test/inspec/shared
     attributes:
-      cookbook-openshift3:
+      openshift3-shared: &SHARED
+        # use experimental repository while https://github.com/openshift/origin/issues/12567 is open
+        yum_repositories:
+          - name: "centos-openshift-origin"
+            baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
+            gpgcheck: false
         # we override these because 10.0.2.15 is whitelisted in $no_proxy
         openshift_common_public_hostname: 10.0.2.15
         openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
-        ose_major_version: 1.3
+        ose_major_version: 1.4
         docker_log_driver: journald
         persistent_storage:
         - name: testpv
@@ -51,17 +65,8 @@ platforms:
            labels: region=infra custom=label
            schedulable: false
         node_servers: *SERVERS
-
-suites:
-  - name: standalone
-    run_list:
-      - role[openshift3-base]
-    verifier:
-      inspec_tests:
-        - test/inspec/standalone
-        - test/inspec/shared
-    attributes:
       cookbook-openshift3:
+        << : *SHARED
         openshift_HA: false
 
   - name: cluster-native
@@ -73,6 +78,7 @@ suites:
         - test/inspec/shared
     attributes:
       cookbook-openshift3:
+        << : *SHARED
         openshift_HA: true
         openshift_cluster_name: test-cluster.domain.local
         etcd_servers: *SERVERS

--- a/providers/openshift_deploy_registry.rb
+++ b/providers/openshift_deploy_registry.rb
@@ -17,6 +17,16 @@ action :create do
     mode '0644'
   end
 
+  execute 'Annotate Hosted Registry Project' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} annotate --overwrite namespace/${namespace_registry} openshift.io/node-selector=${selector_registry}"
+    environment(
+      'selector_registry' => node['cookbook-openshift3']['openshift_hosted_registry_selector'],
+      'namespace_registry' => node['cookbook-openshift3']['openshift_hosted_registry_namespace']
+    )
+    not_if "oc get namespace/${namespace_registry} --template '{{ .metadata.annotations }}' | fgrep -q openshift.io/node-selector:${selector_registry}"
+    only_if 'oc get namespace/${namespace_registry} --no-headers'
+  end
+
   execute 'Deploy Hosted Registry' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm registry --selector=${selector_registry} -n ${namespace_registry} --config=admin.kubeconfig"
     environment(

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -17,6 +17,16 @@ action :create do
     mode '0644'
   end
 
+  execute 'Annotate Hosted Rouger Project' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} annotate --overwrite namespace/${namespace_router} openshift.io/node-selector=${selector_router}"
+    environment(
+      'selector_router' => node['cookbook-openshift3']['openshift_hosted_router_selector'],
+      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
+    )
+    not_if "oc get namespace/${namespace_router} --template '{{ .metadata.annotations }}' | fgrep -q openshift.io/node-selector:${selector_router}"
+    only_if 'oc get namespace/${namespace_router} --no-headers'
+  end
+
   execute 'Deploy Hosted Router' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
     environment(

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -27,6 +27,15 @@ action :create do
     only_if 'oc get namespace/${namespace_router} --no-headers'
   end
 
+  execute 'Create Hosted Router Certificate' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create secret tls router-certs --cert=openshift-router.crt --key=openshift-router.key -n ${namespace_router}"
+    environment(
+      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
+    )
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
+    not_if 'oc get secret router-certs -n $namespace_router --no-headers'
+  end
+
   execute 'Deploy Hosted Router' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
     environment(

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -108,6 +108,7 @@ if node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }
 
   template node['cookbook-openshift3']['openshift_node_config_file'] do
     source 'node.yaml.erb'
+    notifies :run, 'execute[daemon-reload]', :immediately
     notifies :restart, "service[#{node['cookbook-openshift3']['openshift_service_type']}-node]", :immediately
     notifies :enable, "service[#{node['cookbook-openshift3']['openshift_service_type']}-node]", :immediately
   end

--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -25,7 +25,7 @@ auditConfig:
 controllerLeaseTTL: <%= node['cookbook-openshift3']['openshift_master_controller_lease_ttl'] %>
 <% end -%>
 controllers: '*'
-<% if [1.3 , 3.3].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
+<% if [1.3, 3.3, 1.4, 3.4].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
 controllerConfig:
   serviceServingCert:
     signer:
@@ -113,7 +113,7 @@ kubernetesMasterConfig:
   staticNodeNames: []
 <%- end -%>
 masterClients:
-<% if [1.3 , 3.3].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
+<% if [1.3, 3.3, 1.4, 3.4].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf
@@ -121,7 +121,7 @@ masterClients:
     qps: 200
 <%- end -%>
   externalKubernetesKubeConfig: ""
-<% if [1.3 , 3.3].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
+<% if [1.3, 3.3, 1.4, 3.4].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
   openshiftLoopbackClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
     contentType: application/vnd.kubernetes.protobuf

--- a/templates/default/node.yaml.erb
+++ b/templates/default/node.yaml.erb
@@ -7,7 +7,7 @@ iptablesSyncPeriod: "<%= node['cookbook-openshift3']['openshift_node_iptables_sy
 imageConfig:
   format: <%= node['cookbook-openshift3']['openshift_common_registry_url'] %>
   latest: false
-<% if [1.3 , 3.3].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
+<% if [1.3, 3.3, 1.4, 3.4].include? node['cookbook-openshift3']['ose_major_version'].to_f %>
 masterClientConnectionOverrides:
   acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
   contentType: application/vnd.kubernetes.protobuf


### PR DESCRIPTION
As promised in #51, this PR makes this cookbook compatible with the recently released Openshift Origin 1.4.x. I will be adding changeset (and editing the description of this PR) as I successfully deploy more components of the platform.

Note: I use the experimental openshift v1.4.1 packages from the buildlogs centos paas repository (see openshift/origin#12567).

To test, check the 'origin-1.4.x' branch of my Vagrant VM: https://github.com/PerfectMemory/origin-provision-bug-demo . or use the kitchen integration test of this project.

I have successfully deployed and tested so far:
 - [X] master/node deployment (in standalone and openshift_HA configuration)
 - [X] the hosted router addon (had to add missing router-certs secret in default project)
 - [X] the hosted docker-registry addon
 - [X] the cookbook's kitchen integration tests
 - [X] metric addon using my own cookbook (had to add 'view' role to hawkular SA in openshift-infra project and backported the fix to this PR)
 - [X] logging addon using my own cookbook (worked without modifications with v1.4.1 images)

Not in this PR but manually verified:
 - [X] integration test for this cookbook's "hosted metrics" feature #52 , waiting for merge to submit PR
 - [X] integration test for this cookbook's "sample templates", waiting for merge to submit PR

It would be nice to find out if the main configuration files (master-config.yml, scheduler.json, node-config.yaml) have changed between OSE v1.3.x and OSE v1.4.x , but for now the current set of configuration files seem to work.

Bugs/Gotchas with OSE 1.4.x so far:
 - the `origin-node` service spams the following line (times 2) every 10 seconds openshift/origin#11548:
```
Jan 28 09:28:30 master origin-node[28774]: I0128 09:28:30.715289   28774 conversion.go:133] failed to handle multiple devices for container. Skipping Filesystem stats
```
 - docker 1.12 seems unstable, containers that fail their "exec" liveness/readiness probe are redeployed as expected, however the pods stay stuck in `Terminating` state forever; as a workaround I forced `node['cookbook-openshift3']['docker_version'] = '1.10.3-59.el7.centos'` in my `openshift-base` role.

I believe that all changes in this PR are backward-compatible with version 1.3.x while supporting version 1.4.x when it is released to the official CentOS PaaS repository. My platform is already working with version 1.4.1 in the VM and all features seem to work.
