### PR TITLE
Annotate registry/router namespace to use region=infra node-selector

### DIFF
--- a/providers/openshift_deploy_registry.rb
+++ b/providers/openshift_deploy_registry.rb
@@ -17,6 +17,16 @@ action :create do
     mode '0644'
   end
 
+  execute 'Annotate Hosted Registry Project' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} annotate --overwrite namespace/${namespace_registry} openshift.io/node-selector=${selector_registry}"
+    environment(
+      'selector_registry' => node['cookbook-openshift3']['openshift_hosted_registry_selector'],
+      'namespace_registry' => node['cookbook-openshift3']['openshift_hosted_registry_namespace']
+    )
+    not_if "oc get namespace/${namespace_registry} --template '{{ .metadata.annotations }}' | fgrep -q openshift.io/node-selector:${selector_registry}"
+    only_if 'oc get namespace/${namespace_registry} --no-headers'
+  end
+
   execute 'Deploy Hosted Registry' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm registry --selector=${selector_registry} -n ${namespace_registry} --config=admin.kubeconfig"
     environment(

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -17,6 +17,16 @@ action :create do
     mode '0644'
   end
 
+  execute 'Annotate Hosted Rouger Project' do
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} annotate --overwrite namespace/${namespace_router} openshift.io/node-selector=${selector_router}"
+    environment(
+      'selector_router' => node['cookbook-openshift3']['openshift_hosted_router_selector'],
+      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
+    )
+    not_if "oc get namespace/${namespace_router} --template '{{ .metadata.annotations }}' | fgrep -q openshift.io/node-selector:${selector_router}"
+    only_if 'oc get namespace/${namespace_router} --no-headers'
+  end
+
   execute 'Deploy Hosted Router' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
     environment(


### PR DESCRIPTION
In multi-node setup, where the value for the `node['cookbook-openshift3']['openshift_common_default_nodeSelector']` is different from `region=infra` (the default value for router/registry node selector), the cookbook will create router and registry dcs, but those won't run any pods. According to `oc describe dc/router -n default` the reason is that "pod node label selector conflicts with its project node label selector".

As explained in https://blog.chmouel.com/2015/09/23/openshift-default-router-on-master-nodes-but-no-others/, the solution is to annotate the `default` namespace to look like this:

```yaml
apiVersion: v1
kind: Namespace
metadata:
   annotations:
      openshift.io/node-selector: region=infra
```