### PR TITLE
Remove a bunch of unused attributes

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -18,7 +18,6 @@ Installs/Configures Openshift 3.x (>= 3.2)
 
 * `node['cookbook-openshift3']['openshift_adhoc_reboot_node']` -  Defaults to `false`.
 * `node['cookbook-openshift3']['openshift_master_asset_config']` -  Defaults to `nil`.
-* `node['cookbook-openshift3']['use_params_roles']` -  Defaults to `false`.
 * `node['cookbook-openshift3']['use_wildcard_nodes']` -  Defaults to `false`.
 * `node['cookbook-openshift3']['wildcard_domain']` -  Defaults to ``.
 * `node['cookbook-openshift3']['openshift_cluster_name']` -  Defaults to `nil`.
@@ -59,13 +58,11 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['registry_persistent_volume']` -  Defaults to ``.
 * `node['cookbook-openshift3']['yum_repositories']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]`.
 * `node['cookbook-openshift3']['openshift_data_dir']` -  Defaults to `/var/lib/origin`.
-* `node['cookbook-openshift3']['openshift_master_cluster_password']` -  Defaults to `openshift_cluster`.
 * `node['cookbook-openshift3']['openshift_common_base_dir']` -  Defaults to `/etc/origin`.
 * `node['cookbook-openshift3']['openshift_common_master_dir']` -  Defaults to `/etc/origin`.
 * `node['cookbook-openshift3']['openshift_common_node_dir']` -  Defaults to `/etc/origin`.
 * `node['cookbook-openshift3']['openshift_common_portal_net']` -  Defaults to `172.30.0.0/16`.
 * `node['cookbook-openshift3']['openshift_common_first_svc_ip']` -  Defaults to `node['cookbook-openshift3']['openshift_common_portal_net'].split('/')[0].gsub(/\.0$/, '.1')`.
-* `node['cookbook-openshift3']['openshift_common_reverse_svc_ip']` -  Defaults to `node['cookbook-openshift3']['openshift_common_portal_net'].split('/')[0].split('.')[0..1].reverse!.join('.')`.
 * `node['cookbook-openshift3']['openshift_common_default_nodeSelector']` -  Defaults to `region=user`.
 * `node['cookbook-openshift3']['openshift_common_examples_base']` -  Defaults to `/usr/share/openshift/examples`.
 * `node['cookbook-openshift3']['openshift_common_hosted_base']` -  Defaults to `/usr/share/openshift/hosted`.
@@ -73,7 +70,6 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_base_images']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'image-streams-rhel7.json' : 'image-streams-centos7.json`.
 * `node['cookbook-openshift3']['openshift_common_hostname']` -  Defaults to `node['fqdn']`.
 * `node['cookbook-openshift3']['openshift_common_ip']` -  Defaults to `node['ipaddress']`.
-* `node['cookbook-openshift3']['openshift_common_infra_project']` -  Defaults to `%w(default openshift-infra)`.
 * `node['cookbook-openshift3']['openshift_common_public_ip']` -  Defaults to `node['ipaddress']`.
 * `node['cookbook-openshift3']['openshift_common_admin_binary']` -  Defaults to `node['cookbook-openshift3']['deploy_containerized'] == true ? '/usr/local/bin/oadm' : '/usr/bin/oadm`.
 * `node['cookbook-openshift3']['openshift_common_client_binary']` -  Defaults to `node['cookbook-openshift3']['deploy_containerized'] == true ? '/usr/local/bin/oc' : '/usr/bin/oc`.
@@ -124,7 +120,6 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_api_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
 * `node['cookbook-openshift3']['openshift_master_loopback_api_url']` -  Defaults to `https://#{node['fqdn']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
 * `node['cookbook-openshift3']['openshift_master_console_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_console_port']}/console`.
-* `node['cookbook-openshift3']['openshift_master_etcd_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_etcd_port']}`.
 * `node['cookbook-openshift3']['openshift_master_policy']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/policy.json`.
 * `node['cookbook-openshift3']['openshift_master_config_file']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/master-config.yaml`.
 * `node['cookbook-openshift3']['openshift_master_api_sysconfig']` -  Defaults to `/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master-api`.
@@ -133,14 +128,12 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_controllers_systemd']` -  Defaults to `/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers.service`.
 * `node['cookbook-openshift3']['openshift_master_named_certificates']` -  Defaults to `%w()`.
 * `node['cookbook-openshift3']['openshift_master_scheduler_conf']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json`.
-* `node['cookbook-openshift3']['openshift_master_certs_no_etcd']` -  Defaults to `%w(admin.crt master.kubelet-client.crt master.server.crt openshift-master.crt openshift-registry.crt openshift-router.crt etcd.server.crt)`.
 * `node['cookbook-openshift3']['openshift_master_managed_names_additional']` -  Defaults to `%w()`.
 * `node['cookbook-openshift3']['openshift_node_config_dir']` -  Defaults to `#{node['cookbook-openshift3']['openshift_common_node_dir']}/node`.
 * `node['cookbook-openshift3']['openshift_node_config_file']` -  Defaults to `#{node['cookbook-openshift3']['openshift_node_config_dir']}/node-config.yaml`.
 * `node['cookbook-openshift3']['openshift_node_debug_level']` -  Defaults to `2`.
 * `node['cookbook-openshift3']['openshift_node_docker-storage']` -  Defaults to `{ ... }`.
 * `node['cookbook-openshift3']['openshift_node_generated_configs_dir']` -  Defaults to `/var/www/html/node/generated-configs`.
-* `node['cookbook-openshift3']['openshift_node_label']` -  Defaults to `node['cookbook-openshift3']['openshift_common_default_nodeSelector']`.
 * `node['cookbook-openshift3']['openshift_node_iptables_sync_period']` -  Defaults to `5s`.
 * `node['cookbook-openshift3']['openshift_node_max_pod']` -  Defaults to `40`.
 * `node['cookbook-openshift3']['openshift_node_sdn_mtu_sdn']` -  Defaults to `1450`.
@@ -159,13 +152,11 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_hosted_metrics_secrets']` -  Defaults to ``.
 * `node['cookbook-openshift3']['openshift_hosted_metrics_parameters']` -  Defaults to `{ ... }`.
 * `node['cookbook-openshift3']['erb_corsAllowedOrigins']` -  Defaults to `[ ... ]`.
-* `node['cookbook-openshift3']['erb_etcdClientInfo_urls']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['master_generated_certs_dir']` -  Defaults to `/var/www/html/master/generated_certs`.
 * `node['cookbook-openshift3']['etcd_conf_dir']` -  Defaults to `/etc/etcd`.
 * `node['cookbook-openshift3']['etcd_ca_dir']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/ca`.
 * `node['cookbook-openshift3']['etcd_generated_certs_dir']` -  Defaults to `/var/www/html/etcd/generated_certs`.
 * `node['cookbook-openshift3']['etcd_ca_cert']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt`.
-* `node['cookbook-openshift3']['etcd_ca_peer']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt`.
 * `node['cookbook-openshift3']['etcd_cert_file']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/server.crt`.
 * `node['cookbook-openshift3']['etcd_cert_key']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/server.key`.
 * `node['cookbook-openshift3']['etcd_peer_file']` -  Defaults to `#{node['cookbook-openshift3']['etcd_conf_dir']}/peer.crt`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,6 @@
 #
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 
-default['cookbook-openshift3']['use_params_roles'] = false
 default['cookbook-openshift3']['use_wildcard_nodes'] = false
 default['cookbook-openshift3']['wildcard_domain'] = ''
 default['cookbook-openshift3']['openshift_cluster_name'] = nil
@@ -56,13 +55,11 @@ default['cookbook-openshift3']['registry_persistent_volume'] = ''
 default['cookbook-openshift3']['yum_repositories'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]
 
 default['cookbook-openshift3']['openshift_data_dir'] = '/var/lib/origin'
-default['cookbook-openshift3']['openshift_master_cluster_password'] = 'openshift_cluster'
 default['cookbook-openshift3']['openshift_common_base_dir'] = '/etc/origin'
 default['cookbook-openshift3']['openshift_common_master_dir'] = '/etc/origin'
 default['cookbook-openshift3']['openshift_common_node_dir'] = '/etc/origin'
 default['cookbook-openshift3']['openshift_common_portal_net'] = '172.30.0.0/16'
 default['cookbook-openshift3']['openshift_common_first_svc_ip'] = node['cookbook-openshift3']['openshift_common_portal_net'].split('/')[0].gsub(/\.0$/, '.1')
-default['cookbook-openshift3']['openshift_common_reverse_svc_ip'] = node['cookbook-openshift3']['openshift_common_portal_net'].split('/')[0].split('.')[0..1].reverse!.join('.')
 default['cookbook-openshift3']['openshift_common_default_nodeSelector'] = 'region=user'
 default['cookbook-openshift3']['openshift_common_examples_base'] = '/usr/share/openshift/examples'
 default['cookbook-openshift3']['openshift_common_hosted_base'] = '/usr/share/openshift/hosted'
@@ -70,7 +67,6 @@ default['cookbook-openshift3']['openshift_hosted_type'] = node['cookbook-openshi
 default['cookbook-openshift3']['openshift_base_images'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'image-streams-rhel7.json' : 'image-streams-centos7.json'
 default['cookbook-openshift3']['openshift_common_hostname'] = node['fqdn']
 default['cookbook-openshift3']['openshift_common_ip'] = node['ipaddress']
-default['cookbook-openshift3']['openshift_common_infra_project'] = %w(default openshift-infra)
 default['cookbook-openshift3']['openshift_common_public_ip'] = node['ipaddress']
 default['cookbook-openshift3']['openshift_common_admin_binary'] = node['cookbook-openshift3']['deploy_containerized'] == true ? '/usr/local/bin/oadm' : '/usr/bin/oadm'
 default['cookbook-openshift3']['openshift_common_client_binary'] = node['cookbook-openshift3']['deploy_containerized'] == true ? '/usr/local/bin/oc' : '/usr/bin/oc'
@@ -122,7 +118,6 @@ default['cookbook-openshift3']['openshift_master_public_api_url'] = "https://#{n
 default['cookbook-openshift3']['openshift_master_api_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
 default['cookbook-openshift3']['openshift_master_loopback_api_url'] = "https://#{node['fqdn']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
 default['cookbook-openshift3']['openshift_master_console_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_console_port']}/console"
-default['cookbook-openshift3']['openshift_master_etcd_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_etcd_port']}"
 default['cookbook-openshift3']['openshift_master_policy'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/policy.json"
 default['cookbook-openshift3']['openshift_master_config_file'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/master-config.yaml"
 default['cookbook-openshift3']['openshift_master_api_sysconfig'] = "/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master-api"
@@ -131,14 +126,12 @@ default['cookbook-openshift3']['openshift_master_controllers_sysconfig'] = "/etc
 default['cookbook-openshift3']['openshift_master_controllers_systemd'] = "/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers.service"
 default['cookbook-openshift3']['openshift_master_named_certificates'] = %w()
 default['cookbook-openshift3']['openshift_master_scheduler_conf'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json"
-default['cookbook-openshift3']['openshift_master_certs_no_etcd'] = %w(admin.crt master.kubelet-client.crt master.server.crt openshift-master.crt openshift-registry.crt openshift-router.crt etcd.server.crt)
 default['cookbook-openshift3']['openshift_master_managed_names_additional'] = %w()
 default['cookbook-openshift3']['openshift_node_config_dir'] = "#{node['cookbook-openshift3']['openshift_common_node_dir']}/node"
 default['cookbook-openshift3']['openshift_node_config_file'] = "#{node['cookbook-openshift3']['openshift_node_config_dir']}/node-config.yaml"
 default['cookbook-openshift3']['openshift_node_debug_level'] = '2'
 default['cookbook-openshift3']['openshift_node_docker-storage'] = {}
 default['cookbook-openshift3']['openshift_node_generated_configs_dir'] = '/var/www/html/node/generated-configs'
-default['cookbook-openshift3']['openshift_node_label'] = node['cookbook-openshift3']['openshift_common_default_nodeSelector']
 default['cookbook-openshift3']['openshift_node_iptables_sync_period'] = '5s'
 default['cookbook-openshift3']['openshift_node_max_pod'] = '40'
 default['cookbook-openshift3']['openshift_node_sdn_mtu_sdn'] = '1450'
@@ -162,14 +155,11 @@ default['cookbook-openshift3']['openshift_hosted_metrics_parameters'] = {}
 
 default['cookbook-openshift3']['erb_corsAllowedOrigins'] = ['127.0.0.1', 'localhost', node['cookbook-openshift3']['openshift_common_hostname'], node['cookbook-openshift3']['openshift_common_public_hostname']] + node['cookbook-openshift3']['openshift_common_svc_names']
 
-default['cookbook-openshift3']['erb_etcdClientInfo_urls'] = [node['cookbook-openshift3']['openshift_master_etcd_url'], "https://#{node['cookbook-openshift3']['openshift_common_hostname']}:#{node['cookbook-openshift3']['openshift_master_etcd_port']}"]
-
 default['cookbook-openshift3']['master_generated_certs_dir'] = '/var/www/html/master/generated_certs'
 default['cookbook-openshift3']['etcd_conf_dir'] = '/etc/etcd'
 default['cookbook-openshift3']['etcd_ca_dir'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca"
 default['cookbook-openshift3']['etcd_generated_certs_dir'] = '/var/www/html/etcd/generated_certs'
 default['cookbook-openshift3']['etcd_ca_cert'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt"
-default['cookbook-openshift3']['etcd_ca_peer'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt"
 default['cookbook-openshift3']['etcd_cert_file'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/server.crt"
 default['cookbook-openshift3']['etcd_cert_key'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/server.key"
 default['cookbook-openshift3']['etcd_peer_file'] = "#{node['cookbook-openshift3']['etcd_conf_dir']}/peer.crt"


### PR DESCRIPTION
Some attributes from this cookbook appear not to be used anymore:

```
$ for i in $(rgrep ^default attributes* | grep cookbook-openshift3 | cut -d\' -f4); do fgrep -r $i $(ls | egrep -v '(attributes|attribute-cookbook.md|CHANGELOG.md)') -q || echo "Unused attribute: ${i}" ; done
Unused attribute: use_params_roles
Unused attribute: openshift_master_cluster_password
Unused attribute: openshift_common_node_dir
Unused attribute: openshift_common_reverse_svc_ip
Unused attribute: openshift_common_infra_project
Unused attribute: openshift_common_svc_names
Unused attribute: openshift_docker_insecure_registry_arg
Unused attribute: openshift_master_etcd_url
Unused attribute: openshift_master_certs_no_etcd
Unused attribute: openshift_node_label
Unused attribute: erb_etcdClientInfo_urls
Unused attribute: etcd_ca_peer
```

Out of the above list:
 - `openshift_common_node_dir`, `openshift_common_svc_names`, `openshift_docker_insecure_registry_arg` are used to calculate other attributes
 - `etcd_ca_exts_peer`, `etcd_ca_exts_server` are referenced in interpolated attribute name

This PR removes all the unused attributes. Kitchen integration test still pass after the cleanup.