### PR TITLE
Fix permissions within the /etc/origin/node directory

### DIFF
--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -85,9 +85,23 @@ if node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }
   end
 
   execute 'Extract certificate to Node folder' do
-    command "tar xzf #{node['fqdn']}.tgz"
+    command "tar xzf #{node['fqdn']}.tgz && chown -R root:root ."
     cwd node['cookbook-openshift3']['openshift_node_config_dir']
     action :nothing
+  end
+
+  directory "Fix permissions on #{node['cookbook-openshift3']['openshift_node_config_dir']}" do
+    path node['cookbook-openshift3']['openshift_node_config_dir']
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  file "Fix permissions on #{node['cookbook-openshift3']['openshift_node_config_dir']}/ca.crt" do
+    path ::File.join(node['cookbook-openshift3']['openshift_node_config_dir'], 'ca.crt')
+    owner 'root'
+    group 'root'
+    mode '0644'
   end
 
   if node['cookbook-openshift3']['deploy_dnsmasq']

--- a/test/inspec/shared/12_directory_permissions_test.rb
+++ b/test/inspec/shared/12_directory_permissions_test.rb
@@ -1,0 +1,23 @@
+describe directory('/etc/origin') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0755' }
+end
+
+describe directory('/etc/origin/master') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0700' }
+end
+
+describe directory('/etc/origin/node') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0755' }
+end
+
+describe directory('/etc/origin/node/ca.crt') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0644' }
+end


### PR DESCRIPTION
## The issue

I recently discovered that in certain configurations:
 - the `/etc/origin/node` directory has incorrect owner (the vagrant user)
 - upgrading the `origin-node` package resets those permissions and breaks access from unprivileged users to the public origin ca certificate (used to `oc login --certificate-authority=/etc/origin/node/ca.crt`).

This PR solves the issue and adds integration test to ensure that permissions of `/etc/origin/node` directory remains correct at all times.

## Explanation of the bug

I use the excellent [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) plugin. This plugin supports chef, and relocates the location of `Chef::Config[:file_cache_path]` to a Virtualbox shared directory on the host; as a consequence every file created under `Chef::Config[:file_cache_path]` ends up with its uid/gid forced to the uid/gid of the vagrant user.

When `recipe[cookbook-openshift3::nodes_certificates]` runs, it generates the node certificate files under `Chef::Config[:file_cache_path]` then tars everything; the generated certificate files in the tarball now have uid/gid vagrant, as shown below:

```sh
[root@master ~]# tar tvfz /etc/origin/node/master.tgz
drwxrwxr-x vagrant/vagrant   0 2017-01-30 10:00 ./
-rw-r--r-- vagrant/vagrant 1115 2017-01-30 10:00 ./system:node:master.crt
-rw------- vagrant/vagrant 1679 2017-01-30 10:00 ./system:node:master.key
-rw-r--r-- vagrant/vagrant 1070 2017-01-30 10:00 ./ca.crt
-rw------- vagrant/vagrant 5730 2017-01-30 10:00 ./system:node:master.kubeconfig
-rw------- vagrant/vagrant 1679 2017-01-30 10:00 ./server.key
-rw-r--r-- vagrant/vagrant 2205 2017-01-30 10:00 ./server.crt
```

When `recipe[cookbook-openshift3::node]` runs, the tarball is extracted with cwd `/etc/origin/node` and the vagrant uid/gid takes over the /etc/origin/node directory.

When the origin-node package is updated or reinstalled, the `/etc/origin/node` permissions are reset to uid/gid root and mode 700, which breaks access to the ca certificate the next time I run chef-client on the system.