### PR TITLE
Allow to configure the master api deserialization cache size parameter.

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -103,6 +103,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_dns_port']` -  Defaults to `node['cookbook-openshift3']['deploy_dnsmasq'] == true ? '8053' : '53`.
 * `node['cookbook-openshift3']['openshift_master_metrics_public_url']` -  Defaults to `nil`.
 * `node['cookbook-openshift3']['openshift_master_image_bulk_imported']` -  Defaults to `5`.
+* `node['cookbook-openshift3']['openshift_master_deserialization_cache_size']` - Defaults to `50000` (for small deployments a value of `1000` may be more appropriate).
 * `node['cookbook-openshift3']['openshift_master_pod_eviction_timeout']` -  Defaults to ``.
 * `node['cookbook-openshift3']['openshift_master_project_request_message']` -  Defaults to ``.
 * `node['cookbook-openshift3']['openshift_master_project_request_template']` -  Defaults to ``.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,7 @@ default['cookbook-openshift3']['openshift_master_debug_level'] = '2'
 default['cookbook-openshift3']['openshift_master_dns_port'] = node['cookbook-openshift3']['deploy_dnsmasq'] == true ? '8053' : '53'
 default['cookbook-openshift3']['openshift_master_metrics_public_url'] = nil
 default['cookbook-openshift3']['openshift_master_image_bulk_imported'] = 5
+default['cookbook-openshift3']['openshift_master_deserialization_cache_size'] = '50000'
 default['cookbook-openshift3']['openshift_master_pod_eviction_timeout'] = ''
 default['cookbook-openshift3']['openshift_master_project_request_message'] = ''
 default['cookbook-openshift3']['openshift_master_project_request_template'] = ''

--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -95,7 +95,9 @@ kubeletClientInfo:
 kubernetesMasterConfig:
   apiLevels:
   - v1
-  apiServerArguments: null
+  apiServerArguments:
+    deserialization-cache-size:
+    - "<%= node['cookbook-openshift3']['openshift_master_deserialization_cache_size'] %>"
   controllerArguments: null
 <% if node['cookbook-openshift3']['openshift_HA'] %>
   masterCount: <%= @masters_size %>


### PR DESCRIPTION
This PR allows to set:

```yaml
kubernetesMasterConfig:
  apiServerArguments:
    deserialization-cache-size:
    - "1000"
```

In master.yaml, as recommended in https://docs.openshift.com/container-platform/3.3/install_config/install/prerequisites.html#production-level-hardware-requirements openshift/openshift-docs#2542

This parameter is important for us, because we're hit by [this](https://bugzilla.redhat.com/show_bug.cgi?id=1323733) bug, where the openshift master uses huge amount of memory until the oom-killed joins the party.