### PR TITLE
Add integration test for hosted metrics feature

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
   customize:
     cpus: 2
-    memory: 1024
+    memory: 1536
 
 provisioner:
   name: chef_zero
@@ -41,6 +41,8 @@ suites:
         # we override these because 10.0.2.15 is whitelisted in $no_proxy
         openshift_common_public_hostname: 10.0.2.15
         openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
+        openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io
+        openshift_common_default_nodeSelector: region=infra
         ose_major_version: 1.4
         docker_log_driver: journald
         persistent_storage:
@@ -59,6 +61,11 @@ suites:
           claim:
             namespace: default
         registry_persistent_volume: registry-storage
+        openshift_hosted_metrics_parameters:
+          HAWKULAR_METRICS_HOSTNAME: metrics.10.0.2.15.nip.io
+          METRIC_DURATION: "30"
+          IMAGE_VERSION: "v1.4.1"
+          USE_PERSISTENT_STORAGE: "false"
         master_servers: &SERVERS
          - ipaddress: 10.0.2.15
            fqdn: origin-centos-72

--- a/README.md
+++ b/README.md
@@ -131,12 +131,16 @@ The name of the key can be set in upper case or lower case
 
 ```json
 {
+  "openshift_master_metrics_public_url": "metrics.domain.local",
   "openshift_hosted_metrics_parameters": {
-    "hawkular_metrics_hostname": "metric.domain.local",
-    "METRIC_DURATION": "30"
+    "HAWKULAR_METRICS_HOSTNAME": "metric.domain.local",
+    "METRIC_DURATION": "30",
+    "IMAGE_VERSION": "v1.4.1"
   }
 }
 ```
+
+Remember to specify an `IMAGE_VERSION` or the `latest` version will be deployed, which may be incompatible with your openshift cluster version.
 
 =====
 

--- a/providers/openshift_deploy_metrics.rb
+++ b/providers/openshift_deploy_metrics.rb
@@ -60,15 +60,6 @@ action :create do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} new-app --template=metrics-deployer-template --as=system:serviceaccount:openshift-infra:metrics-deployer #{new_resource.metrics_params.map { |opt, value| " -p #{opt}=#{value}" }.join(' ')} -n openshift-infra --config=admin.kubeconfig"
     cwd Chef::Config[:file_cache_path]
     not_if '[ `oc get pod -l \'metrics-infra in (hawkular-cassandra,hawkular-metrics,heapster)\' --no-headers -n openshift-infra | grep -cw Running` -ge 3 ]'
-    notifies :run, 'execute[Wait for image pull and deployer pod to be completed (300 seconds max)]', :immediately
-  end
-
-  execute 'Wait for image pull and deployer pod to be completed (300 seconds max)' do
-    cwd Chef::Config[:file_cache_path]
-    command '[ `oc get pod --selector=app=metrics-deployer-template --sort-by=\'{.metadata.creationTimestamp}\' | tail -1 | awk \'{print $3}\'` == \'Completed\' ]'
-    action :nothing
-    retries 30
-    retry_delay 10
   end
   new_resource.updated_by_last_action(true)
 end

--- a/test/inspec/shared/24_feature_hosted_metrics_test.rb
+++ b/test/inspec/shared/24_feature_hosted_metrics_test.rb
@@ -1,0 +1,17 @@
+# should create service-account for metrics-deployer
+describe command("oc get sa/metrics-deployer -n openshift-infra --template '{{.metadata.name}}'") do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/metrics-deployer/) }
+end
+
+# should create secret for metrics-deployer
+describe command("oc get secret/metrics-deployer -n openshift-infra --template '{{.metadata.name}}'") do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/metrics-deployer/) }
+end
+
+# should create some 'metrics-*' pods (which probably won't have time to complete)
+# at start the pod is metrics-deployer-ID then should be metrics-hawkular etc.
+describe command("oc get pods -n openshift-infra --no-headers | egrep -q '^(metrics|heapster|hawkular)'") do
+  its('exit_status') { should eq 0 }
+end

--- a/test/roles/openshift3-base.json
+++ b/test/roles/openshift3-base.json
@@ -14,7 +14,7 @@
       "openshift_master_sdn_host_subnet_length": 9,
       "openshift_hosted_manage_router": true,
       "openshift_hosted_manage_registry": true,
-      "openshift_hosted_cluster_metrics": false,
+      "openshift_hosted_cluster_metrics": true,
       "deploy_example": false
     }
   },


### PR DESCRIPTION
Here are my integration tests for the "hosted metrics" feature. You will notice that I removed the busy wait for the metrics to be deployed in `providers/openshift_deploy_metrics`, this was not consistent with the manner we deployed the other addons and it made my tests very fragile.