### PR TITLE
Revert e168f9b, use stable repository URLs again

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,7 +52,7 @@ default['cookbook-openshift3']['enabled_firewall_additional_rules_node'] = []
 default['cookbook-openshift3']['enabled_firewall_rules_etcd'] = %w(firewall_etcd)
 default['cookbook-openshift3']['openshift_service_type'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'atomic-openshift' : 'origin'
 default['cookbook-openshift3']['registry_persistent_volume'] = ''
-default['cookbook-openshift3']['yum_repositories'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]
+default['cookbook-openshift3']['yum_repositories'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]
 
 default['cookbook-openshift3']['openshift_data_dir'] = '/var/lib/origin'
 default['cookbook-openshift3']['openshift_common_base_dir'] = '/etc/origin'


### PR DESCRIPTION
This PR makes the cookbook use the stable CentoOS PaaS repository again.

For information, v1.4.1 packages have been pushed to the stable repository last night.