### PR TITLE
Directly use /etc/origin/master/admin.kubeconfig instead of coping it.

### DIFF
--- a/providers/openshift_create_pv.rb
+++ b/providers/openshift_create_pv.rb
@@ -12,14 +12,9 @@ def whyrun_supported?
 end
 
 action :create do
-  remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
-    source 'file:///etc/origin/master/admin.kubeconfig'
-    mode '0644'
-  end
-
   new_resource.persistent_storage.each do |pv|
     execute "Create Persistent Storage : #{pv['name']}" do
-      cwd Chef::Config[:file_cache_path]
+      cwd node['cookbook-openshift3']['openshift_master_config_dir']
       command 'eval echo \'\{\"apiVersion\":\"v1\",\"kind\":\"PersistentVolume\",\"metadata\":\{\"name\":\"${name_pv}\"\},\"spec\":\{\"capacity\":\{\"storage\":\"${capacity_pv}\"\},\"accessModes\":[\"${access_modes_pv}\"],\"nfs\":\{\"path\":\"${path_pv}\",\"server\":\"${server_pv}\"\},\"persistentVolumeReclaimPolicy\":\"${volume_policy}\"\}\}\' | oc create -f - --config=admin.kubeconfig'
       environment(
         'name_pv' => "#{pv['name']}-volume",
@@ -34,7 +29,7 @@ action :create do
 
     next unless pv.key?('claim')
     execute "Create Persistent Claim: #{pv['name']}" do
-      cwd Chef::Config[:file_cache_path]
+      cwd node['cookbook-openshift3']['openshift_master_config_dir']
       command 'eval echo \'\{\"apiVersion\":\"v1\",\"kind\":\"PersistentVolumeClaim\",\"metadata\":\{\"name\":\"${name_pvc}\"\},\"spec\":\{\"resources\":\{\"requests\":\{\"storage\":\"${capacity_pvc}\"\}\},\"accessModes\":[\"${access_modes_pvc}\"]\}\}\' | oc create -f - --config=admin.kubeconfig -n ${namespace}'
       environment(
         'name_pvc' => "#{pv['name']}-claim",

--- a/providers/openshift_deploy_metrics.rb
+++ b/providers/openshift_deploy_metrics.rb
@@ -12,53 +12,48 @@ def whyrun_supported?
 end
 
 action :create do
-  remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
-    source 'file:///etc/origin/master/admin.kubeconfig'
-    mode '0644'
-  end
-
   execute 'Deploy metrics-deployer secret' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} secrets new metrics-deployer ${metrics_deployer_secrets} -n openshift-infra --config=admin.kubeconfig"
     environment(
       'metrics_deployer_secrets' => node['cookbook-openshift3']['openshift_hosted_metrics_secrets'].empty? ? '/dev/null' : node['cookbook-openshift3']['openshift_hosted_metrics_secrets'].map { |opt, value| " #{opt}=#{value}" }
     )
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     only_if '[[ `oc get secrets/metrics-deployer -n openshift-infra --no-headers --config=admin.kubeconfig | wc -l` -eq 0 ]]'
   end
 
   execute 'Create metrics-deployer Service Account' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create serviceaccount metrics-deployer -n openshift-infra --config=admin.kubeconfig"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     only_if '[[ `oc get sa/metrics-deployer -n openshift-infra --no-headers --config=admin.kubeconfig | wc -l` -eq 0 ]]'
   end
 
   execute 'Link secret to metrics-deployer Service Account' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} secrets link metrics-deployer metrics-deployer -n openshift-infra --config=admin.kubeconfig"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if '[[ `oc get -o template sa/metrics-deployer --template={{.secrets}} -n openshift-infra --config=admin.kubeconfig` =~ \'name:metrics-deployer]\' ]]'
   end
 
   execute 'Add edit permission to the openshift-infra project to metrics-deployer SA' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm policy add-role-to-user edit system:serviceaccount:openshift-infra:metrics-deployer -n openshift-infra --config=admin.kubeconfig"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if '[[ `oc get rolebindings -o jsonpath=\'{.items[?(@.metadata.name == "edit")].userNames}\' -n openshift-infra --config=admin.kubeconfig` =~ "system:serviceaccount:openshift-infra:metrics-deployer" ]]'
   end
 
   execute 'Add cluster-reader permission to the openshift-infra project to heapster SA' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:heapster"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if '[[ `oc get clusterrolebindings -o jsonpath=\'{.items[?(@.metadata.name == "cluster-readers")].userNames}\' -n openshift-infra --config=admin.kubeconfig` =~ "system:serviceaccount:openshift-infra:heapster" ]]'
   end
 
   execute 'Add view permission to the openshift-infra project to hawkular SA' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm policy add-role-to-user view system:serviceaccount:openshift-infra:hawkular -n openshift-infra"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if '[[ `oc get rolebinding -o jsonpath=\'{.items[?(@.metadata.name == "view")].userNames}\' -n openshift-infra --config=admin.kubeconfig` =~ "system:serviceaccount:openshift-infra:hawkular" ]]'
   end
 
   execute 'Deploy Cluster Metrics' do
     command "#{node['cookbook-openshift3']['openshift_common_client_binary']} new-app --template=metrics-deployer-template --as=system:serviceaccount:openshift-infra:metrics-deployer #{new_resource.metrics_params.map { |opt, value| " -p #{opt}=#{value}" }.join(' ')} -n openshift-infra --config=admin.kubeconfig"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if '[ `oc get pod -l \'metrics-infra in (hawkular-cassandra,hawkular-metrics,heapster)\' --no-headers -n openshift-infra | grep -cw Running` -ge 3 ]'
   end
   new_resource.updated_by_last_action(true)

--- a/providers/openshift_redeploy_certificate.rb
+++ b/providers/openshift_redeploy_certificate.rb
@@ -12,10 +12,6 @@ def whyrun_supported?
 end
 
 action :redeploy do
-  remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
-    source 'file:///etc/origin/master/admin.kubeconfig'
-    mode '0644'
-  end
   execute 'Backup etcd stuff' do
     command 'tar czvf etcd-backup-$(date +%s).tar.gz -C /etc/etcd/ca /etc/etcd/ca.crt /var/www/html/etcd --ignore-failed-read --remove-files || true'
     cwd '/etc/etcd'

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -8,11 +8,6 @@ master_servers = node['cookbook-openshift3']['master_servers']
 node_servers = node['cookbook-openshift3']['node_servers']
 service_accounts = node['cookbook-openshift3']['openshift_common_service_accounts_additional'].any? ? node['cookbook-openshift3']['openshift_common_service_accounts'] + node['cookbook-openshift3']['openshift_common_service_accounts_additional'] : node['cookbook-openshift3']['openshift_common_service_accounts']
 
-remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
-  source 'file:///etc/origin/master/admin.kubeconfig'
-  mode '0644'
-end
-
 service_accounts.each do |serviceaccount|
   execute "Creation service account: \"#{serviceaccount['name']}\" ; Namespace: \"#{serviceaccount['namespace']}\"" do
     command 'oc create sa ${serviceaccount} -n ${namespace} --config=admin.kubeconfig'
@@ -20,7 +15,7 @@ service_accounts.each do |serviceaccount|
       'serviceaccount' => serviceaccount['name'],
       'namespace' => serviceaccount['namespace']
     )
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if "#{node['cookbook-openshift3']['openshift_common_client_binary']} get sa #{serviceaccount['name']} -n #{serviceaccount['namespace']} --config=admin.kubeconfig"
   end
 
@@ -28,48 +23,48 @@ service_accounts.each do |serviceaccount|
 
   execute "Add SCC to service account: \"#{serviceaccount['name']}\" ; Namespace: \"#{serviceaccount['namespace']}\"" do
     command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} policy add-scc-to-user #{serviceaccount['scc']} -z #{serviceaccount['name']} --config=admin.kubeconfig -n #{serviceaccount['namespace']}"
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if "#{node['cookbook-openshift3']['openshift_common_client_binary']} get scc/#{serviceaccount['scc']} -n #{serviceaccount['namespace']} -o yaml --config=admin.kubeconfig | grep system:serviceaccount:#{serviceaccount['namespace']}:#{serviceaccount['name']}"
   end
 end
 
 execute 'Import Openshift Hosted Examples' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_hosted_base']} --recursive --config=admin.kubeconfig -n openshift || #{node['cookbook-openshift3']['openshift_common_client_binary']} replace -f #{node['cookbook-openshift3']['openshift_common_hosted_base']} --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   ignore_failure true
 end
 
 execute 'Import Openshift db templates' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/db-templates --recursive --config=admin.kubeconfig -n openshift || #{node['cookbook-openshift3']['openshift_common_client_binary']} replace -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/db-templates --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if { node['cookbook-openshift3']['deploy_example'] && node['cookbook-openshift3']['deploy_example_db_templates'] }
   ignore_failure true
 end
 
 execute 'Import Openshift Examples Base image-streams' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/image-streams/#{node['cookbook-openshift3']['openshift_base_images']} --recursive --config=admin.kubeconfig -n openshift || #{node['cookbook-openshift3']['openshift_common_client_binary']} replace -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/image-streams/#{node['cookbook-openshift3']['openshift_base_images']} --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if { node['cookbook-openshift3']['deploy_example'] && node['cookbook-openshift3']['deploy_example_image-streams'] }
   ignore_failure true
 end
 
 execute 'Import Openshift Examples quickstart-templates' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/quickstart-templates --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if { node['cookbook-openshift3']['deploy_example'] && node['cookbook-openshift3']['deploy_example_quickstart-templates'] }
   ignore_failure true
 end
 
 execute 'Import Openshift Examples xpaas-streams' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/xpaas-streams --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if { node['cookbook-openshift3']['deploy_example'] && node['cookbook-openshift3']['deploy_example_xpaas-streams'] }
   ignore_failure true
 end
 
 execute 'Import Openshift Examples xpaas-templates' do
   command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create -f #{node['cookbook-openshift3']['openshift_common_examples_base']}/xpaas-templates --recursive --config=admin.kubeconfig -n openshift"
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if { node['cookbook-openshift3']['deploy_example'] && node['cookbook-openshift3']['deploy_example_xpaas-templates'] }
   ignore_failure true
 end
@@ -84,7 +79,7 @@ node_servers.each do |nodes|
     environment(
       'schedulability' => !nodes.key?(:schedulable) && master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } ? 'False' : nodes['schedulable'].to_s
     )
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     only_if do
       master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } &&
         !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
@@ -96,7 +91,7 @@ node_servers.each do |nodes|
     environment(
       'schedulability' => !nodes.key?(:schedulable) && node_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } ? 'True' : nodes['schedulable'].to_s
     )
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     not_if do
       master_servers.find { |server_node| server_node['fqdn'] == nodes['fqdn'] } ||
         Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
@@ -108,7 +103,7 @@ node_servers.each do |nodes|
     environment(
       'labels' => nodes['labels'].to_s
     )
-    cwd Chef::Config[:file_cache_path]
+    cwd node['cookbook-openshift3']['openshift_master_config_dir']
     only_if do
       nodes.key?('labels') &&
         !Mixlib::ShellOut.new("oc get node | grep #{nodes['fqdn']}").run_command.error?
@@ -118,7 +113,7 @@ end
 
 execute 'Wait up to 30s for nodes registration' do
   command '[[ `oc get node --no-headers --config=admin.kubeconfig | grep -wc "Ready"` -ne 0 ]]'
-  cwd Chef::Config[:file_cache_path]
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
   only_if '[[ `oc get node --no-headers --config=admin.kubeconfig | grep -wc "Ready"` -eq 0 ]]'
   retries 6
   retry_delay 5
@@ -143,9 +138,4 @@ openshift_deploy_metrics 'Deploy Cluster Metrics' do
   only_if do
     node['cookbook-openshift3']['openshift_hosted_cluster_metrics']
   end
-end
-
-file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
-  action :delete
-  only_if { File.exist? "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" }
 end


### PR DESCRIPTION
This PR directly uses `/etc/origin/master/admin.kubeconfig` to authenticate oc commands in LWRP and in `recipe[cookbook-openshift3::master_config_post]` instead of:
 - copying that file into the chef cache directory
 - using the copy (using the cwd attribute of execute resource)
 - then deleting the copy at the end of `recipe[cookbook-openshift3::master_config_post]`.

I believe there should be no breakage from this change since:
 - by definition, the `/etc/origin/master/admin.kubeconfig`  preexisted the copy in `Chef::Config[:file_cache_path`
 - chef run as root (so should have no problem to run `oc` commands that need the file unless these commands are run as a non-root user, which is not the case in this cookbook so far)
I tested the changed with both the kitchen tests and my own VMs, they successfully provision and verify.

The deletion step was breaking any LWRPs relying on the copied admin.kubeconfig if they were invoked after the completion of `recipe[cookbook-openshift3::master_config_post]` , as reported [here](https://github.com/IshentRas/cookbook-openshift3/pull/75#discussion_r100832823). It would also pollute the output of the vagrant chef-solo provisioner with a `cannot access admin.kubeconfig: No such file or directory` in red color.

For example, see this snippet from the openshift_deploy_router LWRP as of [v1.10.34](https://github.com/IshentRas/cookbook-openshift3/blob/v1.10.34/providers/openshift_deploy_router.rb):

```ruby
action :create do
  # This creates the copy of admin.kubeconfig at runtime.
  remote_file "#{Chef::Config[:file_cache_path]}/admin.kubeconfig" do
    source 'file:///etc/origin/master/admin.kubeconfig'
    mode '0644'
  end

  # SNIP

  # This runs command at runtime, but using environment variables which were calculated at compile
  # time, before the admin.kubeconfig copy is recreated by the remote_file resource above
  execute 'Auto Scale Router based on label' do
    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} scale dc/router --replicas=${replica_number} -n ${namespace_router} --config=admin.kubeconfig"
    environment(
      # bug here
      'replica_number' => Mixlib::ShellOut.new("oc get node --no-headers --selector=#{node['cookbook-openshift3']['openshift_hosted_router_selector']} --config=#{Chef::Config[:file_cache_path]}/admin.kubeconfig | wc -l").run_command.stdout.strip,
      'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
    )
    cwd Chef::Config[:file_cache_path]
    not_if '[[ `oc get pod --selector=router=router --config=admin.kubeconfig --no-headers | wc -l` -eq ${replica_number} ]]'
  end

  new_resource.updated_by_last_action(true)
end
```

When admin.kubeconfig is not present in `Chef::Config[:file_cache_path]` (because deleted by earlier run of `recipe[cookbook-openshift3::master_config_post]`, here is what the `replica_number` evaluates to:

```sh
[root@master ~]# cd /tmp/vagrant-cache/chef
[root@master chef]# ls -l admin.kubeconfig
ls: cannot access admin.kubeconfig: No such file or directory
[root@master chef]# oc get node --no-headers --selector=region=infra --config=admin.kubeconfig | wc -l
error: stat admin.kubeconfig: no such file or directory
0
```

This results in scaling my router instances to 0 at every chef run other than the initial one.

If using the full path of `admin.kubeconfig` in `/etc/origin/master` instead, we get the expected number of replicas:

```sh
[root@master chef]# oc get node --no-headers --selector=region=infra --config=/etc/origin/master/admin.kubeconfig | wc -l
1
```