### PR TITLE
Fix CHEF-3694 with etcd-service service defined in 2 places while used in 1.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,10 +24,6 @@ end
 
 service 'httpd'
 
-service 'etcd-service' do
-  service_name node['cookbook-openshift3']['etcd_service_name']
-end
-
 service 'docker'
 
 service 'NetworkManager'

--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -185,6 +185,7 @@ if etcd_servers.find { |server_etcd| server_etcd['fqdn'] == node['fqdn'] }
   end
 
   service 'etcd-service' do
+    service_name node['cookbook-openshift3']['etcd_service_name']
     action [:start, :enable]
   end
 


### PR DESCRIPTION
The `etcd-service` was defined in the default recipe and only used/notified in the etcd_cluster recipe. As a consequence of the double definition of the resource, a CHEF-3694 error was triggered when deploying in Openshift_HA mode.

Log here:
```
==> master: Deprecated features used!
==> master:   Cloning resource attributes for service[etcd-service] from prior resource (CHEF-3694)
==> master: 
==> master: Previous service[etcd-service]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/default.rb:27:in `from_file'
==> master: Current  service[etcd-service]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:187:in `from_file' at 1 location:
```