### PR TITLE
Expand .kitchen.yml to test OSE v1.4.1, v1.3.3 and v1.2.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,62 +23,114 @@ platforms:
     driver:
       vm_hostname: origin-centos-72
 
+openshift3-shared-attributes: &SHARED
+  # uncomment to use experimental CentOS PaaS repository for integration tests
+  #yum_repositories:
+  #  - name: "centos-openshift-origin"
+  #    baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
+  #    gpgcheck: false
+  # we override these because 10.0.2.15 is whitelisted in $no_proxy
+  openshift_common_public_hostname: 10.0.2.15
+  openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
+  openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io
+  openshift_common_default_nodeSelector: region=infra
+  docker_log_driver: journald
+  persistent_storage:
+  - name: testpv
+    capacity: 100Mi
+    access_modes: ReadOnlyMany
+    path: /srv/testpv
+    server: 10.0.2.15
+    claim:
+      namespace: default
+  - name: registry-storage
+    capacity: 100Mi
+    access_modes: ReadWriteMany
+    path: /srv/registry-storage
+    server: 10.0.2.15
+    claim:
+      namespace: default
+  registry_persistent_volume: registry-storage
+  openshift_hosted_metrics_parameters:
+    HAWKULAR_METRICS_HOSTNAME: metrics.10.0.2.15.nip.io
+    METRIC_DURATION: "30"
+    IMAGE_VERSION: "latest" # broken, override in role with explicit version.
+    USE_PERSISTENT_STORAGE: "false"
+  master_servers: &SERVERS
+   - ipaddress: 10.0.2.15
+     fqdn: origin-centos-72
+     labels: region=infra custom=label
+     schedulable: false
+  node_servers: *SERVERS
+
 suites:
-  - name: standalone
+  - name: standalone-ose14
     run_list:
-      - role[openshift3-base]
+      - role[openshift3-base-ose14]
     verifier:
       inspec_tests:
         - test/inspec/standalone
         - test/inspec/shared
     attributes:
-      openshift3-shared: &SHARED
-        # uncomment to use experimental CentOS PaaS repository for integration tests
-        #yum_repositories:
-        #  - name: "centos-openshift-origin"
-        #    baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
-        #    gpgcheck: false
-        # we override these because 10.0.2.15 is whitelisted in $no_proxy
-        openshift_common_public_hostname: 10.0.2.15
-        openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
-        openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io
-        openshift_common_default_nodeSelector: region=infra
-        ose_major_version: 1.4
-        docker_log_driver: journald
-        persistent_storage:
-        - name: testpv
-          capacity: 100Mi
-          access_modes: ReadOnlyMany
-          path: /srv/testpv
-          server: 10.0.2.15
-          claim:
-            namespace: default
-        - name: registry-storage
-          capacity: 100Mi
-          access_modes: ReadWriteMany
-          path: /srv/registry-storage
-          server: 10.0.2.15
-          claim:
-            namespace: default
-        registry_persistent_volume: registry-storage
-        openshift_hosted_metrics_parameters:
-          HAWKULAR_METRICS_HOSTNAME: metrics.10.0.2.15.nip.io
-          METRIC_DURATION: "30"
-          IMAGE_VERSION: "v1.4.1"
-          USE_PERSISTENT_STORAGE: "false"
-        master_servers: &SERVERS
-         - ipaddress: 10.0.2.15
-           fqdn: origin-centos-72
-           labels: region=infra custom=label
-           schedulable: false
-        node_servers: *SERVERS
       cookbook-openshift3:
         << : *SHARED
         openshift_HA: false
 
-  - name: cluster-native
+  - name: cluster-native-ose14
     run_list:
-      - role[openshift3-base]
+      - role[openshift3-base-ose14]
+    verifier:
+      inspec_tests:
+        - test/inspec/cluster-native
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: true
+        openshift_cluster_name: test-cluster.domain.local
+        etcd_servers: *SERVERS
+
+  - name: standalone-ose13
+    run_list:
+      - role[openshift3-base-ose13]
+    verifier:
+      inspec_tests:
+        - test/inspec/standalone
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: false
+
+  - name: cluster-native-ose13
+    run_list:
+      - role[openshift3-base-ose13]
+    verifier:
+      inspec_tests:
+        - test/inspec/cluster-native
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: true
+        openshift_cluster_name: test-cluster.domain.local
+        etcd_servers: *SERVERS
+
+  - name: standalone-ose12
+    run_list:
+      - role[openshift3-base-ose12]
+    verifier:
+      inspec_tests:
+        - test/inspec/standalone
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: false
+
+  - name: cluster-native-ose12
+    run_list:
+      - role[openshift3-base-ose12]
     verifier:
       inspec_tests:
         - test/inspec/cluster-native

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -4,7 +4,7 @@ If you would like to contribute, please do one of the following:
 
 2) Use branches for more complex changes, longer topics, and so on. In general, if the changes are within a single topic, using a pull request is just fine.
 
-3) Run kitchen tests.
+3) Run kitchen tests for all variants listed in `kitchen list`.
 
 4) Once you are ready to publish your changes:
    Update the metadata.rb and push your changes.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Requirements
 * Support Origin version from 1.1.1+
 * Default the installation to 1.4 or 3.4
 
+**Highly recommended**: explicitly set `node['cookbook-openshift3']['ose_version']`, `node['cookbook-openshift3']['ose_major_version']`
+and ideally `node['cookbook-openshift3']['docker_version']` to be safe when a major version is released on the
+CentOS PaaS repository; this cookbook does NOT support upgrade between major versions, so lock your package versions
+in your openshift3 role or environment.
+
+Test Matrix
+===========
+
+| Platform | OSE 1.4.1 | OSE 1.3.3 | OSE 1.2.1 |
+|----------|-----------|-----------|-----------|
+| centos 7.2 | PASS | PASS | open issues: #76 |
+
 Override Attributes
 ===================
 
@@ -427,6 +439,9 @@ Automated Integration Tests (KITCHEN)
 
 This cookbook features [inspect](http://inspec.io/) integration tests,
 for both standalone and cluster-native (HA) variants.
+
+**Attention**: the `.kitchen.yml` tests all the versions listed in the [Test Matrix](#Test Matrix),
+so use `kitchen list` and selective `kitchen converge` to only test a subset of the versions.
 
 Assuming the latest [chef-dk](https://downloads.chef.io/chefdk) is installed,
 running the tests is as simple as:

--- a/test/roles/openshift3-base-ose12.json
+++ b/test/roles/openshift3-base-ose12.json
@@ -1,0 +1,29 @@
+{
+  "name": "openshift3-base",
+  "description": "Openshift3 Common Base Role",
+  "json_class": "Chef::Role",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+    "cookbook-openshift3": {
+      "openshift_deployment_type": "origin",
+      "ose_major_version": "1.2",
+      "ose_version": "1.2.1-1.el7",
+      "openshift_common_portal_net": "172.30.0.0/16",
+      "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
+      "openshift_master_sdn_host_subnet_length": 9,
+      "openshift_hosted_manage_router": true,
+      "openshift_hosted_manage_registry": true,
+      "openshift_hosted_cluster_metrics": true,
+      "deploy_example": false,
+      "openshift_hosted_metrics_parameters": {
+        "IMAGE_VERSION": "v1.2.0"
+      }
+    }
+  },
+  "chef_type": "role",
+  "run_list": [
+    "recipe[cookbook-openshift3::default]"
+  ]
+}

--- a/test/roles/openshift3-base-ose13.json
+++ b/test/roles/openshift3-base-ose13.json
@@ -1,0 +1,29 @@
+{
+  "name": "openshift3-base",
+  "description": "Openshift3 Common Base Role",
+  "json_class": "Chef::Role",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+    "cookbook-openshift3": {
+      "openshift_deployment_type": "origin",
+      "ose_major_version": "1.3",
+      "ose_version": "1.3.3-1.el7",
+      "openshift_common_portal_net": "172.30.0.0/16",
+      "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
+      "openshift_master_sdn_host_subnet_length": 9,
+      "openshift_hosted_manage_router": true,
+      "openshift_hosted_manage_registry": true,
+      "openshift_hosted_cluster_metrics": true,
+      "deploy_example": false,
+      "openshift_hosted_metrics_parameters": {
+        "IMAGE_VERSION": "v1.3.2"
+      }
+    }
+  },
+  "chef_type": "role",
+  "run_list": [
+    "recipe[cookbook-openshift3::default]"
+  ]
+}

--- a/test/roles/openshift3-base-ose14.json
+++ b/test/roles/openshift3-base-ose14.json
@@ -8,14 +8,18 @@
   "override_attributes": {
     "cookbook-openshift3": {
       "openshift_deployment_type": "origin",
-      "ose_major_version": "1.3",
+      "ose_major_version": "1.4",
+      "ose_version": "1.4.1-1.el7",
       "openshift_common_portal_net": "172.30.0.0/16",
       "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
       "openshift_master_sdn_host_subnet_length": 9,
       "openshift_hosted_manage_router": true,
       "openshift_hosted_manage_registry": true,
       "openshift_hosted_cluster_metrics": true,
-      "deploy_example": false
+      "deploy_example": false,
+      "openshift_hosted_metrics_parameters": {
+        "IMAGE_VERSION": "v1.4.1"
+      }
     }
   },
   "chef_type": "role",


### PR DESCRIPTION
This PR expands the kitchen tests to test the standalone/cluster-native installation of OSE v1.4.1, v1.3.3 and v1.2.1 . It implements #85.

Note: while running my tests, I confirm that OSE 1.2.x support needs more work (see #76).

Also, I edited the README to recommend locking down the ose_version, ose_major_version and docker_version. I think that in the future we should make the ose_version mandatory (and maybe calculate the ose_major_version from it).