### PR TITLE
Added cAdvisor port and read-only port for kubelet arguments

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -143,6 +143,8 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_node_maximum_dead_containers']` -  Defaults to `100`.
 * `node['cookbook-openshift3']['openshift_node_image_gc_high_threshold']` -  Defaults to `90`.
 * `node['cookbook-openshift3']['openshift_node_image_gc_low_threshold']` -  Defaults to `80`.
+* `node['cookbook-openshift3']['openshift_node_cadvisor_port']` -  Defaults to `nil`.
+* `node['cookbook-openshift3']['openshift_node_read_only_port']` -  Defaults to `nil`.
 * `node['cookbook-openshift3']['openshift_hosted_manage_router']` -  Defaults to `true`.
 * `node['cookbook-openshift3']['openshift_hosted_router_selector']` -  Defaults to `region=infra`.
 * `node['cookbook-openshift3']['openshift_hosted_router_namespace']` -  Defaults to `default`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -144,6 +144,8 @@ default['cookbook-openshift3']['openshift_node_maximum_dead_containers_per_conta
 default['cookbook-openshift3']['openshift_node_maximum_dead_containers'] = '100'
 default['cookbook-openshift3']['openshift_node_image_gc_high_threshold'] = '90'
 default['cookbook-openshift3']['openshift_node_image_gc_low_threshold'] = '80'
+default['cookbook-openshift3']['openshift_node_cadvisor_port'] = nil # usually set to '4194'
+default['cookbook-openshift3']['openshift_node_read_only_port'] = nil # usually set to '10255'
 
 default['cookbook-openshift3']['openshift_hosted_manage_router'] = true
 default['cookbook-openshift3']['openshift_hosted_router_selector'] = 'region=infra'

--- a/templates/default/node.yaml.erb
+++ b/templates/default/node.yaml.erb
@@ -48,6 +48,14 @@ kubeletArguments:
     - "<%= node['cookbook-openshift3']['openshift_node_image_gc_high_threshold'] %>"
   image-gc-low-threshold:
     - "<%= node['cookbook-openshift3']['openshift_node_image_gc_low_threshold'] %>"
+<% if node['cookbook-openshift3']['openshift_node_cadvisor_port'] %>
+  cadvisor-port:
+    - "<%= node['cookbook-openshift3']['openshift_node_cadvisor_port'] %>"
+<%- end -%>
+<% if node['cookbook-openshift3']['openshift_node_read_only_port'] %>
+  read-only-port:
+    - "<%= node['cookbook-openshift3']['openshift_node_read_only_port'] %>"
+<%- end -%>
 <% if node['cookbook-openshift3']['openshift_cloud_provider'] %>
   cloud-provider:
   - <%= node['cookbook-openshift3']['openshift_cloud_provider'] %>


### PR DESCRIPTION
cAdvisor port and read-only port kubelet arguments allows for some monitoring integrations to be done with OpenShift's underlying Kubernetes metrics. 