### PR TITLE
Added custom master CA certificate

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -127,6 +127,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_api_systemd']` -  Defaults to `/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-api.service`.
 * `node['cookbook-openshift3']['openshift_master_controllers_sysconfig']` -  Defaults to `/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers`.
 * `node['cookbook-openshift3']['openshift_master_controllers_systemd']` -  Defaults to `/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers.service`.
+* `node['cookbook-openshift3']['openshift_master_ca_certificate']` -  Defaults to `{ 'data_bag_name' => nil, 'data_bag_item_name' => nil, 'secret_file' => nil }`.
 * `node['cookbook-openshift3']['openshift_master_named_certificates']` -  Defaults to `%w()`.
 * `node['cookbook-openshift3']['openshift_master_scheduler_conf']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json`.
 * `node['cookbook-openshift3']['openshift_master_managed_names_additional']` -  Defaults to `%w()`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -128,6 +128,7 @@ default['cookbook-openshift3']['openshift_master_api_sysconfig'] = "/etc/sysconf
 default['cookbook-openshift3']['openshift_master_api_systemd'] = "/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-api.service"
 default['cookbook-openshift3']['openshift_master_controllers_sysconfig'] = "/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers"
 default['cookbook-openshift3']['openshift_master_controllers_systemd'] = "/usr/lib/systemd/system/#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers.service"
+default['cookbook-openshift3']['openshift_master_ca_certificate'] = { 'data_bag_name' => nil, 'data_bag_item_name' => nil, 'secret_file' => nil }
 default['cookbook-openshift3']['openshift_master_named_certificates'] = %w()
 default['cookbook-openshift3']['openshift_master_scheduler_conf'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json"
 default['cookbook-openshift3']['openshift_master_managed_names_additional'] = %w()

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -125,6 +125,29 @@ end
 end
 
 if master_servers.first['fqdn'] == node['fqdn']
+  if node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_name'] && node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_item_name']
+    secret_file = node['cookbook-openshift3']['openshift_master_ca_certificate']['secret_file'] || nil
+    ca_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_name'], node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_item_name'], secret_file)
+
+    file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.key" do
+      content Base64.decode64(ca_vars['key_base64'])
+      mode '0600'
+      action :create_if_missing
+    end
+
+    file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt" do
+      content Base64.decode64(ca_vars['cert_base64'])
+      mode '0644'
+      action :create_if_missing
+    end
+
+    file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.serial.txt" do
+      content '1'
+      mode '0644'
+      action :create_if_missing
+    end
+  end
+
   execute 'Create the master certificates' do
     command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
             --hostnames=#{node['cookbook-openshift3']['erb_corsAllowedOrigins'].uniq.join(',')} \

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -142,7 +142,7 @@ if master_servers.first['fqdn'] == node['fqdn']
     end
 
     file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.serial.txt" do
-      content '1'
+      content '00'
       mode '0644'
       action :create_if_missing
     end

--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -21,7 +21,7 @@ if node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_name
   end
 
   file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.serial.txt" do
-    content '1'
+    content '00'
     mode '0644'
     action :create_if_missing
   end

--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -4,6 +4,29 @@
 #
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 
+if node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_name'] && node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_item_name']
+  secret_file = node['cookbook-openshift3']['openshift_master_ca_certificate']['secret_file'] || nil
+  ca_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_name'], node['cookbook-openshift3']['openshift_master_ca_certificate']['data_bag_item_name'], secret_file)
+
+  file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.key" do
+    content Base64.decode64(ca_vars['key_base64'])
+    mode '0600'
+    action :create_if_missing
+  end
+
+  file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt" do
+    content Base64.decode64(ca_vars['cert_base64'])
+    mode '0644'
+    action :create_if_missing
+  end
+
+  file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.serial.txt" do
+    content '1'
+    mode '0644'
+    action :create_if_missing
+  end
+end
+
 execute 'Create the master certificates' do
   command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
           --hostnames=#{node['cookbook-openshift3']['erb_corsAllowedOrigins'].join(',')} \


### PR DESCRIPTION
This PR adds ability to securely specify custom master CA certificate which will be used to generate all other certificates (master server, kubelet, router, registry, etc). So all your OpenShift installation will be  automatically trusted by everybody who trusts that custom CA.

Basically this is a port of OpenShift Ansible playbook [openshift_ca](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_ca/tasks/main.yml).