### PR TITLE
Add support for AWS IAM based integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,59 @@ Data bag item content should be of the form:
 
 Please note: `id` value should be exactly the same as `data_bag_item_name` attribute value from above.
 
+**Alternatively** you can attach IAM policies to your AWS instances and do *not* provide AWS credentials in encrypted data bags. In this case you should have the following attribute for `cookbook-openshift3` cookbook:
+
+```json
+{
+  "openshift_cloud_provider": "aws"
+}
+```
+
+and the following IAM policy attached to your *master* servers:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticloadbalancing:*",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+and the following IAM policy attached to your *node* servers: 
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:Describe*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:AttachVolume",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DetachVolume",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
 =====
 
 Include the default recipe in a CHEF role so as to ease the deployment. 

--- a/attributes/cloud_provider.rb
+++ b/attributes/cloud_provider.rb
@@ -1,2 +1,2 @@
 default['cookbook-openshift3']['openshift_cloud_provider'] = nil
-default['cookbook-openshift3']['openshift_cloud_providers']['aws'] = { 'data_bag_name' => 'cloud-provider', 'data_bag_item_name' => 'aws', 'secret_file' => nil }
+default['cookbook-openshift3']['openshift_cloud_providers']['aws'] = { 'data_bag_name' => nil, 'data_bag_item_name' => nil, 'secret_file' => nil }

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -222,11 +222,13 @@ end
 sysconfig_vars = {}
 
 if node['cookbook-openshift3']['openshift_cloud_provider'] == 'aws'
-  secret_file = node['cookbook-openshift3']['openshift_cloud_providers']['aws']['secret_file'] || nil
-  aws_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'], node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name'], secret_file)
+  if node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'] && node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name']
+    secret_file = node['cookbook-openshift3']['openshift_cloud_providers']['aws']['secret_file'] || nil
+    aws_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'], node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name'], secret_file)
 
-  sysconfig_vars['aws_access_key_id'] = aws_vars['access_key_id']
-  sysconfig_vars['aws_secret_access_key'] = aws_vars['secret_access_key']
+    sysconfig_vars['aws_access_key_id'] = aws_vars['access_key_id']
+    sysconfig_vars['aws_secret_access_key'] = aws_vars['secret_access_key']
+  end
 end
 
 template "/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master" do

--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -29,11 +29,13 @@ end
 sysconfig_vars = {}
 
 if node['cookbook-openshift3']['openshift_cloud_provider'] == 'aws'
-  secret_file = node['cookbook-openshift3']['openshift_cloud_providers']['aws']['secret_file'] || nil
-  aws_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'], node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name'], secret_file)
+  if node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'] && node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name']
+    secret_file = node['cookbook-openshift3']['openshift_cloud_providers']['aws']['secret_file'] || nil
+    aws_vars = Chef::EncryptedDataBagItem.load(node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_name'], node['cookbook-openshift3']['openshift_cloud_providers']['aws']['data_bag_item_name'], secret_file)
 
-  sysconfig_vars['aws_access_key_id'] = aws_vars['access_key_id']
-  sysconfig_vars['aws_secret_access_key'] = aws_vars['secret_access_key']
+    sysconfig_vars['aws_access_key_id'] = aws_vars['access_key_id']
+    sysconfig_vars['aws_secret_access_key'] = aws_vars['secret_access_key']
+  end
 end
 
 template "/etc/sysconfig/#{node['cookbook-openshift3']['openshift_service_type']}-master" do


### PR DESCRIPTION
This PR adds support for AWS cloud provider integration using proper IAM policies and eliminates the need to provide raw AWS credentials within Chef encrypted data bags. So now two options for AWS integration are supported: credentials based and IAM based.