### PR TITLE
Replace most hard link usage with local copy; fixes #101.

### DIFF
--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -82,9 +82,8 @@ if etcd_servers.find { |server_etcd| server_etcd['fqdn'] == node['fqdn'] }
         end
       end
 
-      link "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/ca.crt" do
-        to "#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
-        link_type :hard
+      remote_file "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/ca.crt" do
+        source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
       end
 
       execute "Create a tarball of the etcd certs for #{etcd_master['fqdn']}" do

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -89,9 +89,8 @@ if master_servers.first['fqdn'] == node['fqdn']
       creates "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-master-#{master_server['fqdn']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}client.crt"
     end
 
-    link "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-master-#{master_server['fqdn']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt" do
-      to "#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
-      link_type :hard
+    remote_file "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-master-#{master_server['fqdn']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt" do
+      source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
     end
 
     execute "Create a tarball of the etcd master certs for #{master_server['fqdn']}" do
@@ -166,9 +165,8 @@ if master_servers.first['fqdn'] == node['fqdn']
     end
 
     %w(ca.crt ca.key ca.serial.txt admin.crt admin.key admin.kubeconfig master.kubelet-client.crt master.kubelet-client.key openshift-master.crt openshift-master.key openshift-master.kubeconfig openshift-registry.crt openshift-registry.key openshift-registry.kubeconfig openshift-router.crt master.proxy-client.crt master.proxy-client.key openshift-router.key openshift-router.kubeconfig serviceaccounts.private.key serviceaccounts.public.key).each do |master_certificate|
-      link "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/#{master_certificate}" do
-        to "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}"
-        link_type :hard
+      remote_file "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/#{master_certificate}" do
+        source "file://#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}"
       end
     end
 


### PR DESCRIPTION
This PR should fix #101 .

Note: I used filesystem copy instead of symlink because the copied files will be used in a tarball, so using symlink would not work.