### PR TITLE
Fix CHEF-3694 warning due to redundant package resource

### DIFF
--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -209,10 +209,6 @@ if master_servers.first['fqdn'] != node['fqdn']
     cwd node['cookbook-openshift3']['openshift_master_config_dir']
     action :nothing
   end
-
-  package node['cookbook-openshift3']['openshift_service_type'] do
-    not_if { node['cookbook-openshift3']['deploy_containerized'] }
-  end
 end
 
 package "#{node['cookbook-openshift3']['openshift_service_type']}-master" do


### PR DESCRIPTION
This PR fixes the following CHEF-3694 warning:

```sh
Deprecated features used!
  Cloning resource attributes for yum_package[origin] from prior resource
Previous yum_package[origin]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master.rb:50:in `from_file'
Current  yum_package[origin]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:213:in `from_file' at 1 location:
    - /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
```

The fix was simple, remove the package resource in `recipe/master_cluster.rb`, because nowadays that recipe is always included from `recipe/master.rb`, after the affected resource has been declared.

I check with kitchen tests (both in standalone and HA mode) and it still converges fine.