### PR TITLE
Make the xfer http server listen only on specific addresses instead of 0.0.0.0

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -60,8 +60,48 @@ end
 
 ruby_block 'Change HTTPD port xfer' do
   block do
-    openshift_settings = Chef::Util::FileEdit.new('/etc/httpd/conf/httpd.conf')
-    openshift_settings.search_file_replace_line(/^Listen/, "Listen #{node['cookbook-openshift3']['httpd_xfer_port']}")
+    # Minimal implementation of Chef::FileEdit, which can idempotently replace
+    # a single `Listen` line with multiple `Listen` lines (one per http_address)
+    # if #search_file_replace_line is invoked with a multiline Regexp.
+    class MyFileEdit
+      def initialize(filepath)
+        raise ArgumentError, "File '#{filepath}' does not exist" unless File.exist?(filepath)
+        @contents = File.open(filepath, &:read)
+        @original_pathname = filepath
+        @changes = false
+      end
+
+      def search_file_replace_line(regex, newline)
+        @changes ||= contents.gsub!(regex, newline)
+      end
+
+      def write_file
+        if @changes
+          backup_pathname = original_pathname + '.old'
+          FileUtils.cp(original_pathname, backup_pathname, preserve: true)
+          File.open(original_pathname, 'w') do |newfile|
+            newfile.write(contents)
+            newfile.flush
+          end
+        end
+        @changes = false
+      end
+
+      private
+
+      attr_reader :contents, :original_pathname
+    end
+
+    http_addresses = [node['cookbook-openshift3']['etcd_servers'], node['cookbook-openshift3']['master_servers']].each_with_object([]) do |candidate_servers, memo|
+      this_server = candidate_servers.find { |server_candidate| server_candidate['fqdn'] == node['fqdn'] }
+      memo << this_server['ipaddress'] if this_server
+    end.sort.uniq
+
+    openshift_settings = MyFileEdit.new('/etc/httpd/conf/httpd.conf')
+    openshift_settings.search_file_replace_line(
+      /(^Listen.*?\n)+/m,
+      http_addresses.map { |addr| "Listen #{addr}:#{node['cookbook-openshift3']['httpd_xfer_port']}\n" }.join
+    )
     openshift_settings.write_file
   end
   action :nothing


### PR DESCRIPTION
By default, the http server used to transfer the generated certificates listens to `0.0.0.0:9999` on the first openshift master and/or etcd master. This is insecure since anyone can get the generated certificates if the xfer servers have a public IP address.

This PR makes the http server only listen to the IP address configured in the attributes which hopefully is not publicly reachable. It should not break usage of the cookbook since every resource which retrieves the generated servers uses `node['cookbook-openshift3']['master_servers'][0]['ipaddress']`, which is the address we listen on.

Before this PR:
```sh
[root@master ~]# netstat -ntlp | grep :9999
tcp6       0      0 :::9999                 :::*                    LISTEN      1156/httpd          
```

After this PR:
```sh
[root@master ~]# netstat -ntlp | grep 9999
tcp        0      0 192.168.91.13:9999      0.0.0.0:*               LISTEN      7774/httpd          
```