### PR TITLE
Fix master named certificates when certificate CN is also listed in alternative names.

### DIFF
--- a/providers/openshift_create_master.rb
+++ b/providers/openshift_create_master.rb
@@ -29,6 +29,8 @@ action :create do
       print 'No SAN detected'
     ensure
       names = subject_alt_name.nil? ? common_name : common_name + subject_alt_name
+      names = names.uniq # openshift fails if the same entry is listed twice, eg. when common_name is also listed in subject_alt_name
+
       named_hash = {}
       named_hash.store('certfile', named['certfile'])
       named_hash.store('keyfile', named['keyfile'])


### PR DESCRIPTION
I want to expose the openshift console using an official wildcard certificate, by declaring the certificate file and key in `node['cookbook-openshift3']['openshift_master_named_certificates']`.

The certificate I have is special because the common name is also listed in the alternative names:
```sh
$ openssl x509 -in wildcardcert.pem -text | egrep -A1 'Subject:|Alternative Name'
        Subject: OU=Domain Control Validated, CN=*.cloud.acme.com
        Subject Public Key Info:
--
            X509v3 Subject Alternative Name: 
                DNS:*.cloud.acme.com, DNS:cloud.acme.com
```

As a result, this cookbook generates the following in /etc/origin/master/master-config.yml:

```yaml
...

servingInfo:
  ...
  namedCertificates:
  - certFile: /etc/ssl/acme.pem
    keyFile: /etc/ssl/acme.key
    names:
    - "*.cloud.acme.com"
    - "*.cloud.acme.com"
    - "cloud.acme.com"
```

When there is duplicate entry in `serviceInfo.namedCertificates.names` the origin-master-* services will fail to start with the following message:
```sh
# journalctl -f -u origin-master-controllers.service                        
-- Logs begin at Wed 2017-03-15 10:55:05 UTC. --
Mar 16 15:23:09 master01 systemd[1]: Stopping Atomic OpenShift Master Controllers...
Mar 16 15:23:09 master01 systemd[1]: Starting Atomic OpenShift Master Controllers...
Mar 16 15:23:09 master01 origin-master-controllers[71308]: Invalid MasterConfig /etc/origin/master/master-config.yaml
Mar 16 15:23:09 master01 origin-master-controllers[71308]: servingInfo.namedCertificates[0].names[1]: Invalid value: "*.cloud.acme.com": this name is already used in another named certificate
Mar 16 15:23:09 master01 systemd[1]: origin-master-controllers.service: main process exited, code=exited, status=255/n/a
Mar 16 15:23:09 master01 systemd[1]: Failed to start Atomic OpenShift Master Controllers.
Mar 16 15:23:09 master01 systemd[1]: Unit origin-master-controllers.service entered failed state. 
Mar 16 15:23:09 master01 systemd[1]: origin-master-controllers.service failed.
```

This PR removes the duplicate entries to fix the problem.