### PR TITLE
Distinct hostnames for internal and public api access

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ openshift3-shared-attributes: &SHARED
   #    baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
   #    gpgcheck: false
   # we override these because 10.0.2.15 is whitelisted in $no_proxy
-  openshift_common_public_hostname: 10.0.2.15
+  openshift_common_api_hostname: 10.0.2.15
   openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
   openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io
   openshift_common_default_nodeSelector: region=infra

--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -25,7 +25,8 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['master_servers']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['etcd_servers']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['node_servers']` -  Defaults to `[ ... ]`.
-* `node['cookbook-openshift3']['openshift_common_public_hostname']` -  Defaults to `node['fqdn']`.
+* `node['cookbook-openshift3']['openshift_common_api_hostname']` -  Defaults to `node['fqdn']`.
+* `node['cookbook-openshift3']['openshift_common_public_hostname']` -  Defaults to `node['cookbook-openshift3']['openshift_common_api_hostname']`.
 * `node['cookbook-openshift3']['openshift_master_embedded_etcd']` -  Defaults to `true`.
 * `node['cookbook-openshift3']['openshift_master_etcd_port']` -  Defaults to `4001`.
 * `node['cookbook-openshift3']['master_etcd_cert_prefix']` -  Defaults to ``.
@@ -118,7 +119,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_access_token_max_seconds']` -  Defaults to `86400`.
 * `node['cookbook-openshift3']['openshift_master_auth_token_max_seconds']` -  Defaults to `500`.
 * `node['cookbook-openshift3']['openshift_master_public_api_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
-* `node['cookbook-openshift3']['openshift_master_api_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
+* `node['cookbook-openshift3']['openshift_master_api_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_api_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
 * `node['cookbook-openshift3']['openshift_master_loopback_api_url']` -  Defaults to `https://#{node['fqdn']}:#{node['cookbook-openshift3']['openshift_master_api_port']}`.
 * `node['cookbook-openshift3']['openshift_master_console_url']` -  Defaults to `https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_console_port']}/console`.
 * `node['cookbook-openshift3']['openshift_master_policy']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/policy.json`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,12 +13,14 @@ default['cookbook-openshift3']['etcd_servers'] = []
 default['cookbook-openshift3']['node_servers'] = []
 
 if node['cookbook-openshift3']['openshift_HA']
-  default['cookbook-openshift3']['openshift_common_public_hostname'] = node['cookbook-openshift3']['openshift_cluster_name']
+  default['cookbook-openshift3']['openshift_common_api_hostname'] = node['cookbook-openshift3']['openshift_cluster_name']
+  default['cookbook-openshift3']['openshift_common_public_hostname'] = node['cookbook-openshift3']['openshift_common_api_hostname']
   default['cookbook-openshift3']['openshift_master_embedded_etcd'] = false
   default['cookbook-openshift3']['openshift_master_etcd_port'] = '2379'
   default['cookbook-openshift3']['master_etcd_cert_prefix'] = 'master.etcd-'
 else
-  default['cookbook-openshift3']['openshift_common_public_hostname'] = node['fqdn']
+  default['cookbook-openshift3']['openshift_common_api_hostname'] = node['fqdn']
+  default['cookbook-openshift3']['openshift_common_public_hostname'] = node['cookbook-openshift3']['openshift_common_api_hostname']
   default['cookbook-openshift3']['openshift_master_embedded_etcd'] = true
   default['cookbook-openshift3']['openshift_master_etcd_port'] = '4001'
   default['cookbook-openshift3']['master_etcd_cert_prefix'] = ''
@@ -120,7 +122,7 @@ default['cookbook-openshift3']['openshift_master_session_secrets_file'] = "#{nod
 default['cookbook-openshift3']['openshift_master_access_token_max_seconds'] = '86400'
 default['cookbook-openshift3']['openshift_master_auth_token_max_seconds'] = '500'
 default['cookbook-openshift3']['openshift_master_public_api_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
-default['cookbook-openshift3']['openshift_master_api_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
+default['cookbook-openshift3']['openshift_master_api_url'] = "https://#{node['cookbook-openshift3']['openshift_common_api_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
 default['cookbook-openshift3']['openshift_master_loopback_api_url'] = "https://#{node['fqdn']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
 default['cookbook-openshift3']['openshift_master_console_url'] = "https://#{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_console_port']}/console"
 default['cookbook-openshift3']['openshift_master_policy'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/policy.json"
@@ -161,7 +163,7 @@ default['cookbook-openshift3']['openshift_hosted_cluster_metrics'] = false
 default['cookbook-openshift3']['openshift_hosted_metrics_secrets'] = ''
 default['cookbook-openshift3']['openshift_hosted_metrics_parameters'] = {}
 
-default['cookbook-openshift3']['erb_corsAllowedOrigins'] = ['127.0.0.1', 'localhost', node['cookbook-openshift3']['openshift_common_hostname'], node['cookbook-openshift3']['openshift_common_public_hostname']] + node['cookbook-openshift3']['openshift_common_svc_names']
+default['cookbook-openshift3']['erb_corsAllowedOrigins'] = ['127.0.0.1', 'localhost', node['cookbook-openshift3']['openshift_common_hostname'], node['cookbook-openshift3']['openshift_common_api_hostname'], node['cookbook-openshift3']['openshift_common_public_hostname']].uniq + node['cookbook-openshift3']['openshift_common_svc_names']
 
 default['cookbook-openshift3']['master_generated_certs_dir'] = '/var/www/html/master/generated_certs'
 default['cookbook-openshift3']['etcd_add_additional_nodes'] = false

--- a/providers/openshift_create_master.rb
+++ b/providers/openshift_create_master.rb
@@ -30,6 +30,7 @@ action :create do
     ensure
       names = subject_alt_name.nil? ? common_name : common_name + subject_alt_name
       names = names.uniq # openshift fails if the same entry is listed twice, eg. when common_name is also listed in subject_alt_name
+      names -= [node['cookbook-openshift3']['openshift_common_api_hostname']] # named certificate apply only to public hostnames, not internal ones.
 
       named_hash = {}
       named_hash.store('certfile', named['certfile'])

--- a/providers/openshift_create_master.rb
+++ b/providers/openshift_create_master.rb
@@ -29,6 +29,8 @@ action :create do
       print 'No SAN detected'
     ensure
       names = subject_alt_name.nil? ? common_name : common_name + subject_alt_name
+      names = names.uniq # openshift fails if the same entry is listed twice, eg. when common_name is also listed in subject_alt_name
+
       named_hash = {}
       named_hash.store('certfile', named['certfile'])
       named_hash.store('keyfile', named['keyfile'])

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -314,7 +314,7 @@ ruby_block "Mask #{node['cookbook-openshift3']['openshift_service_type']}-master
 end
 
 execute 'Wait for API to become available' do
-  command "echo | openssl s_client -connect #{node['cookbook-openshift3']['openshift_common_public_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']} -servername #{node['cookbook-openshift3']['openshift_common_public_hostname']}"
+  command "echo | openssl s_client -connect #{node['cookbook-openshift3']['openshift_common_api_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']} -servername #{node['cookbook-openshift3']['openshift_common_api_hostname']}"
   retries 15
   retry_delay 2
   notifies :start, "service[#{node['cookbook-openshift3']['openshift_service_type']}-master-controllers]", :immediately


### PR DESCRIPTION
Note: this PR builds on top of #107 .

When trying to expose the openshift console under a public URL that uses a real certificate (not one managed by the openshift CA), I found out that `node['cookbook-openshift3']['openshift_master_api_url']` cannot use a certificate that is not managed by the openshift CA.

This is the difference between the `openshift_master_public_api_url` and `openshift_master_api_url` attributes: the former is public (and can use a public certificate) while the latter is internal to openshift (and must use a certificated signed by the openshift CA). A consequence is that the hostname used in `node['cookbook-openshift3']['openshift_master_api_url']` cannot be included in the list of master named certificates, even if the certificate lists that value by accident. For reference, read https://docs.openshift.com/container-platform/3.4/install_config/certificate_customization.html#configuring-custom-certificates (especially the section about masterURL).

I introduce in this PR a new attribute, `node['cookbook-openshift3']['openshift_common_api_hostname']` (name up for discussion), which is used to build the internal URL attributes. Then I refactored the existing `node['cookbook-openshift3']['openshift_common_public_hostname']` to be used to build the public URLs attributes; the `node['cookbook-openshift3']['openshift_common_public_hostname']` attribute defaults to the value of `node['cookbook-openshift3']['openshift_common_api_hostname']` for backward compatibility.

To expose the openshift console using a public certificate, configure your role like this:
```yaml
    "cookbook-openshift3": {
      "openshift_HA": true,
      "openshift_cluster_name": "cloud.acme.com",
      ...
      # "openshift_common_api_hostname": ${openshift_cluster_name},
      "openshift_common_public_hostname": "openshift.cloud.acme.com",
      # "openshift_master_console_url": "https://${openshift_common_public_hostname}:8443/console",
      # "openshift_master_public_api_url": "https://${openshift_common_public_hostname}:8443",
      # "openshift_master_api_url": "https://${openshift_common_api_hostname}:8443",
      "openshift_master_named_certificates": [
        {"certfile": "/path/to/cert.pem", "keyfile": "/path/to/key.pem"}
      ]
    }
  }
}
```

Please review and tell me what you think @IshentRas and @ianmiell .