### PR TITLE
Allow to specify custom certificate for hosted router

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -150,6 +150,8 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_hosted_router_selector']` -  Defaults to `region=infra`.
 * `node['cookbook-openshift3']['openshift_hosted_router_namespace']` -  Defaults to `default`.
 * `node['cookbook-openshift3']['openshift_hosted_manage_registry']` -  Defaults to `true`.
+* `node['cookbook-openshift3']['openshift_hosted_router_certfile']` - Defaults to `"#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.crt"`.
+* `node['cookbook-openshift3']['openshift_hosted_router_keyfile']` - Defaults to `"#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.key"`.
 * `node['cookbook-openshift3']['openshift_hosted_registry_selector']` -  Defaults to `region=infra`.
 * `node['cookbook-openshift3']['openshift_hosted_registry_namespace']` -  Defaults to `default`.
 * `node['cookbook-openshift3']['openshift_hosted_cluster_metrics']` -  Defaults to `false`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -152,6 +152,8 @@ default['cookbook-openshift3']['openshift_node_read_only_port'] = nil # usually 
 default['cookbook-openshift3']['openshift_hosted_manage_router'] = true
 default['cookbook-openshift3']['openshift_hosted_router_selector'] = 'region=infra'
 default['cookbook-openshift3']['openshift_hosted_router_namespace'] = 'default'
+default['cookbook-openshift3']['openshift_hosted_router_certfile'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.crt"
+default['cookbook-openshift3']['openshift_hosted_router_keyfile'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.key"
 
 default['cookbook-openshift3']['openshift_hosted_manage_registry'] = true
 default['cookbook-openshift3']['openshift_hosted_registry_selector'] = 'region=infra'

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -23,8 +23,10 @@ action :create do
   end
 
   execute 'Create Hosted Router Certificate' do
-    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create secret generic router-certs --from-file=openshift-router.crt --from-file=openshift-router.key -n ${namespace_router}"
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} create secret generic router-certs --from-file tls.crt=${certfile} --from-file tls.key=${keyfile} -n ${namespace_router}"
     environment(
+      'certfile' => node['cookbook-openshift3']['openshift_hosted_router_certfile'],
+      'keyfile' => node['cookbook-openshift3']['openshift_hosted_router_keyfile'],
       'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']
     )
     cwd node['cookbook-openshift3']['openshift_master_config_dir']


### PR DESCRIPTION
This PR implements #103.

Its scope is much more reduced than I thought, because the cookbook already pre-creates the router-certs secrets with the generated certificates. I only had to move the hardcoded certificate names into an attribute, that I can override in my roles and voila!

Simple usage:
 1. pre-create the certificate and key files on disk before `recipe['cookbook-openshift3::default']` runs
 2. have the following attributes configured in a role or environment:

```sh
node['cookbook-openshift3']['openshift_hosted_router_certfile'] = '/path/to/custom/openshift-router.crt"
node['cookbook-openshift3']['openshift_hosted_router_keyfile'] = '/path/to/custom/openshift-router.key"
```

If the router has already been provisioned with the defaults openshift-signed certificates, run:
```
oc delete dc/router svc/router secret/router-certs
```
Before converging the node again.