### PR TITLE
Allow public hostname resolve to multiple IPs

### DIFF
--- a/providers/openshift_create_master.rb
+++ b/providers/openshift_create_master.rb
@@ -48,7 +48,7 @@ action :create do
     template new_resource.master_file do
       source 'master.yaml.erb'
       variables(
-        erb_corsAllowedOrigins: new_resource.origins + [Resolv.getaddress(node['cookbook-openshift3']['openshift_common_public_hostname'])],
+        erb_corsAllowedOrigins: new_resource.origins + Resolv.getaddresses(node['cookbook-openshift3']['openshift_common_public_hostname']).sort,
         standalone_registry: new_resource.standalone_registry,
         erb_master_named_certificates: named_certificates,
         etcd_servers: new_resource.etcd_servers,


### PR DESCRIPTION
If `openshift_common_public_hostname` resolves to multiple IPs there was continues changes to `corsAllowedOrigins` section at `master-config.yaml` with every Chef client run. 

Fixes #111.