### PR TITLE
Make master api peers list their endpoint ipaddress in their certificate SANs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,8 +29,8 @@ openshift3-shared-attributes: &SHARED
   #  - name: "centos-openshift-origin"
   #    baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
   #    gpgcheck: false
-  # we override these because 10.0.2.15 is whitelisted in $no_proxy
-  openshift_common_api_hostname: 10.0.2.15
+  # attention: if using http proxies, make sure that '10.0.2.15.nip.io' is whitelisted in $no_proxy!
+  openshift_common_api_hostname: 10.0.2.15.nip.io
   openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
   openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io
   openshift_common_default_nodeSelector: region=infra

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -137,7 +137,7 @@ if master_servers.first['fqdn'] == node['fqdn']
 
   execute 'Create the master certificates' do
     command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
-            --hostnames=#{node['cookbook-openshift3']['erb_corsAllowedOrigins'].uniq.join(',')} \
+            --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [master_servers.first['ipaddress']]).uniq.join(',')} \
             --master=#{node['cookbook-openshift3']['openshift_master_api_url']} \
             --public-master=#{node['cookbook-openshift3']['openshift_master_public_api_url']} \
             --cert-dir=#{node['cookbook-openshift3']['openshift_master_config_dir']} --overwrite=false"
@@ -169,7 +169,7 @@ if master_servers.first['fqdn'] == node['fqdn']
 
     execute "Create the master peer certificates for #{peer_server['fqdn']}" do
       command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} create-master-certs \
-              --hostnames=#{node['cookbook-openshift3']['erb_corsAllowedOrigins'].uniq.join(',').gsub(master_servers.first['ipaddress'], peer_server['ipaddress'])} \
+              --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [peer_server['ipaddress']]).uniq.join(',')} \
               --master=#{node['cookbook-openshift3']['openshift_master_api_url']} \
               --public-master=#{node['cookbook-openshift3']['openshift_master_public_api_url']} \
               --cert-dir=#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']} --overwrite=false"

--- a/test/inspec/shared/11_functioning_openshift_test.rb
+++ b/test/inspec/shared/11_functioning_openshift_test.rb
@@ -43,3 +43,11 @@ describe command('oc get node/$HOSTNAME --no-headers') do
   its('exit_status') { should eq 0 }
   its('stdout') { should match(/SchedulingDisabled/) }
 end
+
+# the openshift master api endpoints should by queriable using the https protocol; in other words,
+# `curl --fail https://$(oc get endpoints kubernetes -n default -o jsonpath='{.subsets[*].addresses[0].ip}'):8443`
+# should always work, even if the endpoint ipaddress is not explicitly listed in `node['cookbook-openshift3']['erb_corsAllowedOrigins']`.
+describe command('curl --fail --cacert /etc/origin/node/ca.crt https://10.0.2.15:8443') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should include('/api/v1') }
+end


### PR DESCRIPTION
# The bug

Each openshift master API peer should list their endpoint ip-address in their certificate SANs.

We did not catch this error in the kitchen spec before because we used `node['cookbook-openshift3']['openshift_common_api_hostname'] = <ipaddress>`, resulting in the ipaddress being included in the certificate SANs automatically.

# Context

Using an HA deployment of openshift, where `node['cookbook-openshift3']['openshift_common_api_hostname'] = <some resolvable dns name pointing to at least one master api instance>`.

I want to make the prometheus monitoring system scrape the `kubernetes-apiserver` target defined in the sample configuration file here: https://github.com/prometheus/prometheus/blob/14d0604aba95c7bb434f3a7687f7903bbe4fd81f/documentation/examples/prometheus-kubernetes.yml#L15-L48 . The scraping works like this:
 - prometheus queries kubernetes to find all endpoints for service "kubernetes" in the "default" namespace.
 - for each endpoint found, it scrapes the `https://<endpoint ipaddress>:8443/metrics` URL (prometheus has the openshift CA mounted in /var/secrets).
 - when the <endpoint ipaddress> is not listed in the certificate returned by the master API instance at that address then the certificate validation fails because of hostname not being listed in the certificate

In my (test) setup, `node['cookbook-openshift3']['openshift_common_api_hostname']` = '192.168.33.220.xip.io' (and not: 192.168.33.220); as a consequence, `192.168.33.220.xip.io` is listed in the SANs of certificate at /etc/origin/master/master.server.crt but `192.168.33.220` is not.

# Reproducing the bug in the kitchen VMs

Assuming that `node['cookbook-openshift3']['openshift_common_api_hostname']` = '10.0.2.15.nip.io` is set in .kitchen.yml , provision one of the test VMs and log into it.

```sh
[root@origin-centos-72 ~]# curl --fail --cacert /etc/origin/node/ca.crt  https://$(oc get endpoints kubernetes -n default -o jsonpath='{.subsets[*].addresses[0].ip}'):8443
curl: (51) Unable to communicate securely with peer: requested domain name does not match the server's certificate.
root@origin-centos-72 ~]# echo $(oc get endpoints kubernetes -n default -o jsonpath='{.subsets[*].addresses[0].ip}')
10.0.2.15
[root@origin-centos-72 ~]# openssl x509 -in /etc/origin/master/master.server.crt  -text | grep -A1 'Subject Alternative Name'
            X509v3 Subject Alternative Name: 
                DNS:10.0.2.15.nip.io, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:localhost, DNS:openshift, DNS:openshift.default, DNS:openshift.default.svc, DNS:openshift.default.svc.cluster.local, DNS:origin-centos-72, DNS:127.0.0.1, DNS:172.30.0.1, IP Address:127.0.0.1, IP Address:172.30.0.1
```

After applying this PR, the above curl command should work.
I have have added inspec example to ensure no regression.
  
