### PR TITLE
Include the openshift standalone masterIP in the SANs of master.server.crt

### DIFF
--- a/recipes/master_standalone.rb
+++ b/recipes/master_standalone.rb
@@ -29,7 +29,7 @@ end
 
 execute 'Create the master certificates' do
   command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
-          --hostnames=#{node['cookbook-openshift3']['erb_corsAllowedOrigins'].join(',')} \
+          --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [node['cookbook-openshift3']['openshift_common_ip']]).uniq.join(',')} \
           --master=#{node['cookbook-openshift3']['openshift_master_api_url']} \
           --public-master=#{node['cookbook-openshift3']['openshift_master_public_api_url']} \
           --cert-dir=#{node['cookbook-openshift3']['openshift_master_config_dir']} --overwrite=false"


### PR DESCRIPTION
This PR is the equivalent of #119 but for standalone master deployments.

Without this PR:
```
[root@standalone-master master]#  curl --cacert /etc/origin/node/ca.crt https://192.168.122.12:8443
curl: (51) Unable to communicate securely with peer: requested domain name does not match the server's certificate.
```

With this PR:
```sh
[root@standalone-master master]#  curl --cacert /etc/origin/node/ca.crt https://192.168.122.12:8443
{
  "paths": [
    "/api",
    "/api/v1",
    "/apis",
    "/controllers",
    "/healthz",
    "/healthz/ping",
    "/healthz/ready",
    "/metrics",
    "/oapi",
    "/oapi/v1",
    "/swaggerapi/"
  ]
}
```