### PR TITLE
Only copy master certificates which exist in /etc/origin/master

### DIFF
--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -164,6 +164,8 @@ if master_servers.first['fqdn'] == node['fqdn']
     %w(ca.crt ca.key ca.serial.txt admin.crt admin.key admin.kubeconfig master.kubelet-client.crt master.kubelet-client.key openshift-master.crt openshift-master.key openshift-master.kubeconfig openshift-registry.crt openshift-registry.key openshift-registry.kubeconfig openshift-router.crt master.proxy-client.crt master.proxy-client.key openshift-router.key openshift-router.kubeconfig serviceaccounts.private.key serviceaccounts.public.key service-signer.crt service-signer.key).each do |master_certificate|
       remote_file "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/#{master_certificate}" do
         source "file://#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}"
+        only_if { ::File.file?("#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}") }
+
       end
     end
 


### PR DESCRIPTION
This PR should fix for #122 , where the copy of some master certificates would fail on openshift v1.5.0 because some certificate files which existed in v1.4.1 , are gone in v1.5.0. The PR should be backward-compatible with all openshift versions earlier than v1.5.0.

Here is the differences in the files present in `/etc/origin/master` between openshift v1.4.1 and v1.50, on a fresh installation using this cookbook:
```diff
--- v1.4.1.txt	2017-05-19 13:43:21.977050811 +0200
+++ v1.5.0.txt	2017-05-19 13:43:06.240996513 +0200
@@ -22,12 +22,6 @@
 openshift-master.crt
 openshift-master.key
 openshift-master.kubeconfig
-openshift-registry.crt
-openshift-registry.key
-openshift-registry.kubeconfig
-openshift-router.crt
-openshift-router.key
-openshift-router.kubeconfig
 policy.json
 scheduler.json
 serviceaccounts.private.key
```