### PR TITLE
Fix CHEF-3694 warning with master certificates

### DIFF
--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -187,7 +187,7 @@ if master_servers.first['fqdn'] == node['fqdn']
               node['cookbook-openshift3']['openshift_master_certs']
             end
 
-    certs.each do |master_certificate|
+    certs.uniq.each do |master_certificate|
       remote_file "#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/#{master_certificate}" do
         source "file://#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}"
         only_if { ::File.file?("#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{master_certificate}") }


### PR DESCRIPTION
A tiny PR to fix a recently introduced CHEF-3694 error due to some certificate file names being iterated twice (because the name is both listed in `node['cookbook-openshift3']['openshift_master_certs']` and added in openshift version-specific case).

Typical symptoms seen in chef-client output:
```sh
  Cloning resource attributes for remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.crt] from prior resource
Previous remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.crt]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file'
Current  remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.crt]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file' at 1 location:
    - /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
  Cloning resource attributes for remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.key] from prior resource
Previous remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.key]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file'
Current  remote_file[/var/www/html/master/generated_certs/openshift-rtlbrumamdvrs02/service-signer.key]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file' at 1 location:
    - /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
  Cloning resource attributes for remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.crt] from prior resource 
Previous remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.crt]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file'
Current  remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.crt]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file' at 1 location:
    - /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
  Cloning resource attributes for remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.key] from prior resource 
Previous remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.key]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file'
Current  remote_file[/var/www/html/master/generated_certs/openshift-master/service-signer.key]: /var/chef/cache/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:191:in `block (2 levels) in from_file' at 1 location:
    - /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.

```