### PR TITLE
Remove duplicated code between etcd_cluster and master_cluster recipes.

### DIFF
--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -13,6 +13,15 @@ if master_servers.find { |server_master| server_master['fqdn'] == node['fqdn'] }
       notifies :run, 'ruby_block[Change HTTPD port xfer]', :immediately
       notifies :enable, 'service[httpd]', :immediately
     end
+
+    directory node['cookbook-openshift3']['etcd_ca_dir'] do
+      owner 'root'
+      group 'root'
+      mode '0700'
+      action :create
+      recursive true
+    end
+
     %w(certs crl fragments).each do |etcd_ca_sub_dir|
       directory "#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_ca_sub_dir}" do
         owner 'root'

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -16,39 +16,6 @@ node['cookbook-openshift3']['enabled_firewall_rules_master_cluster'].each do |ru
 end
 
 if master_servers.first['fqdn'] == node['fqdn']
-  directory node['cookbook-openshift3']['etcd_ca_dir'] do
-    owner 'root'
-    group 'root'
-    mode '0700'
-    action :create
-    recursive true
-  end
-
-  template node['cookbook-openshift3']['etcd_openssl_conf'] do
-    source 'openssl.cnf.erb'
-  end
-
-  %w(certs crl fragments).each do |etcd_ca_sub_dir|
-    directory "#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_ca_sub_dir}" do
-      owner 'root'
-      group 'root'
-      mode '0700'
-      action :create
-      recursive true
-    end
-  end
-
-  execute "ETCD Generate index.txt #{node['fqdn']}" do
-    command 'touch index.txt'
-    cwd node['cookbook-openshift3']['etcd_ca_dir']
-    creates "#{node['cookbook-openshift3']['etcd_ca_dir']}/index.txt"
-  end
-
-  file "#{node['cookbook-openshift3']['etcd_ca_dir']}/serial" do
-    content '01'
-    action :create_if_missing
-  end
-
   %W(/var/www/html/master #{node['cookbook-openshift3']['master_generated_certs_dir']}).each do |path|
     directory path do
       mode '0755'
@@ -104,7 +71,7 @@ execute 'Extract certificate to Master folder' do
   action :nothing
 end
 
-%w(client.crt client.key ca.cert).each do |certificate_type|
+%w(client.crt client.key ca.crt).each do |certificate_type|
   file "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}#{certificate_type}" do
     owner 'root'
     group 'root'


### PR DESCRIPTION
This PR removed duplicated code in `recipe[master_cluster]` which is supposed to initialize the etcd ca directory, work which has already been done by `recipe[etcd_cluster]` which is included earlier in the run list.

This fixes the CHEF-3694 spam reported in #121 , which I report again below:

```sh
       Deprecated features used!
         Cloning resource attributes for template[/etc/etcd/ca/openssl.cnf] from prior resource
       Previous template[/etc/etcd/ca/openssl.cnf]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:26:in `from_file'
       Current  template[/etc/etcd/ca/openssl.cnf]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:27:in `from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:27:in `from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for directory[/etc/etcd/ca/certs] from prior resource
       Previous directory[/etc/etcd/ca/certs]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:17:in `block in from_file'
       Current  directory[/etc/etcd/ca/certs]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for directory[/etc/etcd/ca/crl] from prior resource
       Previous directory[/etc/etcd/ca/crl]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:17:in `block in from_file'
       Current  directory[/etc/etcd/ca/crl]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for directory[/etc/etcd/ca/fragments] from prior resource
       Previous directory[/etc/etcd/ca/fragments]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:17:in `block in from_file'
       Current  directory[/etc/etcd/ca/fragments]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:32:in `block in from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for execute[ETCD Generate index.txt origin-centos-72] from prior resource
       Previous execute[ETCD Generate index.txt origin-centos-72]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:30:in `from_file'
       Current  execute[ETCD Generate index.txt origin-centos-72]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:41:in `from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:41:in `from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for file[/etc/etcd/ca/serial] from prior resource
       Previous file[/etc/etcd/ca/serial]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/etcd_cluster.rb:36:in `from_file'
       Current  file[/etc/etcd/ca/serial]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:47:in `from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:47:in `from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for service[origin-master-api] from prior resource
       Previous service[origin-master-api]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/default.rb:10:in `from_file'
       Current  service[origin-master-api]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:363:in `from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:363:in `from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.
         Cloning resource attributes for service[origin-master-controllers] from prior resource
       Previous service[origin-master-controllers]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/default.rb:15:in `from_file'
       Current  service[origin-master-controllers]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:367:in `from_file' at 1 location:
           - /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_cluster.rb:367:in `from_file'
          See https://docs.chef.io/deprecations_resource_cloning.html for further details.

```