### PR TITLE
Fix CHEF-3694 warning that triggered while waiting for node registration

### DIFF
--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -73,16 +73,16 @@ openshift_create_pv 'Create Persistent Storage' do
   persistent_storage node['cookbook-openshift3']['persistent_storage']
 end
 
-node_servers.reject { |h| h.key?('skip_run') }.each do |nodes|
-  execute "Wait up to 30s for nodes registration [Size : #{node_servers.size.to_i}]" do
-    command "[[ `oc get node --no-headers --config=admin.kubeconfig | grep -wc \"Ready\"` -ne #{node_servers.size.to_i} ]]"
-    cwd node['cookbook-openshift3']['openshift_master_config_dir']
-    only_if "[[ `oc get node --no-headers --config=admin.kubeconfig | wc -l` -ne #{node_servers.size.to_i} ]]"
-    retries 6
-    retry_delay 5
-    ignore_failure true
-  end
+execute "Wait up to 30s for nodes registration [Size : #{node_servers.size.to_i}]" do
+  command "[[ `oc get node --no-headers --config=admin.kubeconfig | grep -wc \"Ready\"` -ne #{node_servers.size.to_i} ]]"
+  cwd node['cookbook-openshift3']['openshift_master_config_dir']
+  only_if "[[ `oc get node --no-headers --config=admin.kubeconfig | wc -l` -ne #{node_servers.size.to_i} ]]"
+  retries 6
+  retry_delay 5
+  ignore_failure true
+end
 
+node_servers.reject { |h| h.key?('skip_run') }.each do |nodes|
   execute "Set schedulability for Master node : #{nodes['fqdn']}" do
     command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} manage-node #{nodes['fqdn']} --schedulable=${schedulability} --config=admin.kubeconfig"
     environment(


### PR DESCRIPTION
This PR fixes the following CHEF-3694 error:

```sh
==> master:   Cloning resource attributes for execute[Wait up to 30s for nodes registration [Size : 3]] from prior resource
==> master: Previous execute[Wait up to 30s for nodes registration [Size : 3]]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_config_post.rb:77:in `block in from_file'
==> master: Current  execute[Wait up to 30s for nodes registration [Size : 3]]: /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/master_config_post.rb:77:in `block in from_file' at 1 location:
==> master:     - /tmp/vagrant-cache/chef/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
==> master:    See https://docs.chef.io/deprecations_resource_cloning.html for further details.
```

The error triggered because the "Wait up to 30s for nodes registration" resource is declared within a loop, while the waiting code does not have to be in that loop. My fix was just to move the resource outside of the loop body to make it declared only once.