### PR TITLE
certificate_server separation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,9 @@ RELEASE
 - document diff to last tag
 - up the metadata value
 - tag the cookbook app, commit push
-- knife cookbook site share cookbook-openshift3
+- commit
+- git push --tag
+- knife cookbook site share cookbook-openshift3 # on rothko
 
 ''', cc: '', from: 'cookbook-openshift3@jenkins.meirionconsulting.tk', replyTo: '', subject: 'Build OK', to: 'ian.miell@gmail.com, william17.burton@gmail.com'
   stage('cleanup') {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['cookbook-openshift3']['openshift_HA'] = false
 default['cookbook-openshift3']['master_servers'] = []
 default['cookbook-openshift3']['etcd_servers'] = []
 default['cookbook-openshift3']['node_servers'] = []
+default['cookbook-openshift3']['certificate_server'] = {}
 
 if node['cookbook-openshift3']['openshift_HA']
   default['cookbook-openshift3']['openshift_common_api_hostname'] = node['cookbook-openshift3']['openshift_cluster_name']

--- a/recipes/certificate_server.rb
+++ b/recipes/certificate_server.rb
@@ -1,0 +1,20 @@
+master_servers = node['cookbook-openshift3']['master_servers']
+certificate_server = node['cookbook-openshift3']['certificate_server'] == {} ? master_servers.first : node['cookbook-openshift3']['certificate_server']
+
+# Certificate server needs oadm installed
+package node['cookbook-openshift3']['openshift_service_type'] do
+  action :install
+  version node['cookbook-openshift3']['ose_version'] unless node['cookbook-openshift3']['ose_version'].nil?
+  only_if { certificate_server['fqdn'] == node['fqdn'] }
+end
+
+# If this is the certificate server, create the master certs. TODO: refactor this.
+execute 'Create the master certificates' do
+  command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
+          --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [node['cookbook-openshift3']['openshift_common_ip']]).uniq.join(',')} \
+          --master=#{node['cookbook-openshift3']['openshift_master_api_url']} \
+          --public-master=#{node['cookbook-openshift3']['openshift_master_public_api_url']} \
+          --cert-dir=#{node['cookbook-openshift3']['openshift_master_config_dir']} --overwrite=false"
+  creates "#{node['cookbook-openshift3']['openshift_master_config_dir']}/master.server.key"
+  only_if { certificate_server['fqdn'] == node['fqdn'] }
+end

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 
+certificate_server = node['cookbook-openshift3']['certificate_server'] == {} ? node['cookbook-openshift3']['master_servers'].first : node['cookbook-openshift3']['certificate_server']
+
 include_recipe 'iptables::default'
 include_recipe 'selinux_policy::default'
 
@@ -126,7 +128,7 @@ ruby_block 'Change HTTPD port xfer' do
       attr_reader :contents, :original_pathname
     end
 
-    http_addresses = [node['cookbook-openshift3']['etcd_servers'], node['cookbook-openshift3']['master_servers']].each_with_object([]) do |candidate_servers, memo|
+    http_addresses = [node['cookbook-openshift3']['etcd_servers'], node['cookbook-openshift3']['master_servers'], [certificate_server]].each_with_object([]) do |candidate_servers, memo|
       this_server = candidate_servers.find { |server_candidate| server_candidate['fqdn'] == node['fqdn'] }
       memo << this_server['ipaddress'] if this_server
     end.sort.uniq
@@ -142,4 +144,5 @@ ruby_block 'Change HTTPD port xfer' do
   notifies :restart, 'service[httpd]', :immediately
 end
 
+include_recipe 'cookbook-openshift3::certificate_server'
 include_recipe 'cookbook-openshift3::cloud_provider'

--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -6,113 +6,112 @@
 
 etcd_servers = node['cookbook-openshift3']['etcd_servers']
 master_servers = node['cookbook-openshift3']['master_servers']
+certificate_server = node['cookbook-openshift3']['certificate_server'] == {} ? master_servers.first : node['cookbook-openshift3']['certificate_server']
 
-if master_servers.find { |server_master| server_master['fqdn'] == node['fqdn'] }
-  if master_servers.first['fqdn'] == node['fqdn']
-    package 'httpd' do
-      notifies :run, 'ruby_block[Change HTTPD port xfer]', :immediately
-      notifies :enable, 'service[httpd]', :immediately
-    end
+if certificate_server['fqdn'] == node['fqdn']
+  package 'httpd' do
+    notifies :run, 'ruby_block[Change HTTPD port xfer]', :immediately
+    notifies :enable, 'service[httpd]', :immediately
+  end
 
-    directory node['cookbook-openshift3']['etcd_ca_dir'] do
+  directory node['cookbook-openshift3']['etcd_ca_dir'] do
+    owner 'root'
+    group 'root'
+    mode '0700'
+    action :create
+    recursive true
+  end
+
+  %w(certs crl fragments).each do |etcd_ca_sub_dir|
+    directory "#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_ca_sub_dir}" do
       owner 'root'
       group 'root'
       mode '0700'
       action :create
       recursive true
     end
+  end
 
-    %w(certs crl fragments).each do |etcd_ca_sub_dir|
-      directory "#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_ca_sub_dir}" do
-        owner 'root'
-        group 'root'
-        mode '0700'
-        action :create
-        recursive true
+  template node['cookbook-openshift3']['etcd_openssl_conf'] do
+    source 'openssl.cnf.erb'
+  end
+
+  execute "ETCD Generate index.txt #{node['fqdn']}" do
+    command 'touch index.txt'
+    cwd node['cookbook-openshift3']['etcd_ca_dir']
+    creates "#{node['cookbook-openshift3']['etcd_ca_dir']}/index.txt"
+  end
+
+  file "#{node['cookbook-openshift3']['etcd_ca_dir']}/serial" do
+    content '01'
+    action :create_if_missing
+  end
+
+  execute "ETCD Generate CA certificate for #{node['fqdn']}" do
+    command "openssl req -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -newkey rsa:4096 -keyout ca.key -new -out ca.crt -x509 -extensions etcd_v3_ca_self -batch -nodes -days #{node['cookbook-openshift3']['etcd_default_days']} -subj /CN=etcd-signer@$(date +%s)"
+    environment 'SAN' => ''
+    cwd node['cookbook-openshift3']['etcd_ca_dir']
+    creates "#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
+  end
+
+  %W(/var/www/html/etcd #{node['cookbook-openshift3']['etcd_generated_certs_dir']} #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd).each do |path|
+    directory path do
+      mode '0755'
+      owner 'apache'
+      group 'apache'
+    end
+  end
+
+  %w(ca.crt ca.key).each do |etcd_export_certificate|
+    remote_file "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd/#{etcd_export_certificate}" do
+      source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_export_certificate}"
+      mode '0644'
+    end
+  end
+
+  etcd_servers.each do |etcd_master|
+    directory "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}" do
+      mode '0755'
+      owner 'apache'
+      group 'apache'
+    end
+
+    %w(server peer).each do |etcd_certificates|
+      execute "ETCD Create the #{etcd_certificates} csr for #{etcd_master['fqdn']}" do
+        command "openssl req -new -keyout #{etcd_certificates}.key -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -out #{etcd_certificates}.csr -reqexts #{node['cookbook-openshift3']['etcd_req_ext']} -batch -nodes -subj /CN=#{etcd_master['fqdn']}"
+        environment 'SAN' => "IP:#{etcd_master['ipaddress']}"
+        cwd "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}"
+        creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/#{etcd_certificates}.csr"
+      end
+
+      execute "ETCD Sign and create the #{etcd_certificates} crt for #{etcd_master['fqdn']}" do
+        command "openssl ca -name #{node['cookbook-openshift3']['etcd_ca_name']} -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -out #{etcd_certificates}.crt -in #{etcd_certificates}.csr -extensions #{node['cookbook-openshift3']["etcd_ca_exts_#{etcd_certificates}"]} -batch"
+        environment 'SAN' => ''
+        cwd "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}"
+        creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/#{etcd_certificates}.crt"
       end
     end
 
-    template node['cookbook-openshift3']['etcd_openssl_conf'] do
-      source 'openssl.cnf.erb'
+    remote_file "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/ca.crt" do
+      source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
     end
 
-    execute "ETCD Generate index.txt #{node['fqdn']}" do
-      command 'touch index.txt'
-      cwd node['cookbook-openshift3']['etcd_ca_dir']
-      creates "#{node['cookbook-openshift3']['etcd_ca_dir']}/index.txt"
+    execute "Create a tarball of the etcd certs for #{etcd_master['fqdn']}" do
+      command "tar czvf #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz -C #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']} . && chown apache: #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz"
+      creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz"
     end
+  end
 
-    file "#{node['cookbook-openshift3']['etcd_ca_dir']}/serial" do
-      content '01'
-      action :create_if_missing
-    end
+  openshift_add_etcd 'Add additional etcd nodes to cluster' do
+    etcd_servers etcd_servers
+    only_if { node['cookbook-openshift3']['etcd_add_additional_nodes'] }
+  end
 
-    execute "ETCD Generate CA certificate for #{node['fqdn']}" do
-      command "openssl req -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -newkey rsa:4096 -keyout ca.key -new -out ca.crt -x509 -extensions etcd_v3_ca_self -batch -nodes -days #{node['cookbook-openshift3']['etcd_default_days']} -subj /CN=etcd-signer@$(date +%s)"
-      environment 'SAN' => ''
-      cwd node['cookbook-openshift3']['etcd_ca_dir']
-      creates "#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
-    end
-
-    %W(/var/www/html/etcd #{node['cookbook-openshift3']['etcd_generated_certs_dir']} #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd).each do |path|
-      directory path do
-        mode '0755'
-        owner 'apache'
-        group 'apache'
-      end
-    end
-
-    %w(ca.crt ca.key).each do |etcd_export_certificate|
-      remote_file "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd/#{etcd_export_certificate}" do
-        source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/#{etcd_export_certificate}"
-        mode '0644'
-      end
-    end
-
-    etcd_servers.each do |etcd_master|
-      directory "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}" do
-        mode '0755'
-        owner 'apache'
-        group 'apache'
-      end
-
-      %w(server peer).each do |etcd_certificates|
-        execute "ETCD Create the #{etcd_certificates} csr for #{etcd_master['fqdn']}" do
-          command "openssl req -new -keyout #{etcd_certificates}.key -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -out #{etcd_certificates}.csr -reqexts #{node['cookbook-openshift3']['etcd_req_ext']} -batch -nodes -subj /CN=#{etcd_master['fqdn']}"
-          environment 'SAN' => "IP:#{etcd_master['ipaddress']}"
-          cwd "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}"
-          creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/#{etcd_certificates}.csr"
-        end
-
-        execute "ETCD Sign and create the #{etcd_certificates} crt for #{etcd_master['fqdn']}" do
-          command "openssl ca -name #{node['cookbook-openshift3']['etcd_ca_name']} -config #{node['cookbook-openshift3']['etcd_openssl_conf']} -out #{etcd_certificates}.crt -in #{etcd_certificates}.csr -extensions #{node['cookbook-openshift3']["etcd_ca_exts_#{etcd_certificates}"]} -batch"
-          environment 'SAN' => ''
-          cwd "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}"
-          creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/#{etcd_certificates}.crt"
-        end
-      end
-
-      remote_file "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}/ca.crt" do
-        source "file://#{node['cookbook-openshift3']['etcd_ca_dir']}/ca.crt"
-      end
-
-      execute "Create a tarball of the etcd certs for #{etcd_master['fqdn']}" do
-        command "tar czvf #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz -C #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']} . && chown apache: #{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz"
-        creates "#{node['cookbook-openshift3']['etcd_generated_certs_dir']}/etcd-#{etcd_master['fqdn']}.tgz"
-      end
-    end
-
-    openshift_add_etcd 'Add additional etcd nodes to cluster' do
-      etcd_servers etcd_servers
-      only_if { node['cookbook-openshift3']['etcd_add_additional_nodes'] }
-    end
-
-    openshift_add_etcd 'Remove additional etcd nodes to cluster' do
-      etcd_servers etcd_servers
-      etcd_servers_to_remove node['cookbook-openshift3']['etcd_remove_servers']
-      not_if { node['cookbook-openshift3']['etcd_remove_servers'].empty? }
-      action :remove_node
-    end
+  openshift_add_etcd 'Remove additional etcd nodes to cluster' do
+    etcd_servers etcd_servers
+    etcd_servers_to_remove node['cookbook-openshift3']['etcd_remove_servers']
+    not_if { node['cookbook-openshift3']['etcd_remove_servers'].empty? }
+    action :remove_node
   end
 end
 
@@ -145,9 +144,9 @@ if etcd_servers.find { |server_etcd| server_etcd['fqdn'] == node['fqdn'] }
     end
   end
 
-  remote_file "Retrieve certificate from ETCD Master[#{master_servers.first['fqdn']}]" do
+  remote_file "Retrieve certificate from ETCD Master[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['etcd_conf_dir']}/etcd-#{node['fqdn']}.tgz"
-    source "http://#{master_servers.first['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/generated_certs/etcd-#{node['fqdn']}.tgz"
+    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/generated_certs/etcd-#{node['fqdn']}.tgz"
     action :create_if_missing
     notifies :run, 'execute[Extract certificate to ETCD folder]', :immediately
     retries 12

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -7,6 +7,7 @@
 master_servers = node['cookbook-openshift3']['master_servers']
 node_servers = node['cookbook-openshift3']['node_servers']
 path_certificate = node['cookbook-openshift3']['use_wildcard_nodes'] ? 'wildcard_nodes.tgz' : "#{node['fqdn']}.tgz"
+certificate_server = node['cookbook-openshift3']['certificate_server'] == {} ? master_servers.first : node['cookbook-openshift3']['certificate_server']
 
 # Use ruby_block for copying OpenShift CA to system CA trust
 ruby_block 'Update ca trust' do
@@ -97,9 +98,9 @@ if node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }
     not_if { node['cookbook-openshift3']['deploy_containerized'] }
   end
 
-  remote_file "Retrieve certificate from Master[#{master_servers.first['fqdn']}]" do
+  remote_file "Retrieve certificate from Master[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_node_config_dir']}/#{node['fqdn']}.tgz"
-    source "http://#{master_servers.first['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{path_certificate}"
+    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{path_certificate}"
     action :create_if_missing
     notifies :run, 'execute[Extract certificate to Node folder]', :immediately
     retries 12

--- a/recipes/validate.rb
+++ b/recipes/validate.rb
@@ -17,6 +17,10 @@ if node['cookbook-openshift3']['openshift_HA'] && node['cookbook-openshift3']['o
   Chef::Application.fatal!('A Cluster Name must be defined via "openshift_cluster_name"')
 end
 
+if !node['cookbook-openshift3']['openshift_HA'] && node['cookbook-openshift3']['certificate_server'] != {}
+  Chef::Application.fatal!('Separate certificate server and master standalone not supported.')
+end
+
 if node['cookbook-openshift3']['openshift_hosted_cluster_metrics']
   unless node['cookbook-openshift3']['openshift_metrics_cassandra_storage_types'].any? { |t| t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']) == 0 }
     Chef::Application.fatal!('Key openshift_metrics_cassandra_storage_types is not valid. Please refer to the documentation for supprted types')


### PR DESCRIPTION
This is an attempt to allow the admin to have a separate server where certificates are created.

It is designed to be back-compatible, where the default is to go back to the first-master method.

If a separate certificate_server is specified, then the chef recipes can run on there to create the certs and serve them from the same endpoint. Or the certs can be created by some other method and left placed there for download.

The motivation behind this was to twofold:

- Remove the requirement for a 'static' first master that also held the certificates - we had a first master that needed to be moved and this complicated things.

- Give the opportunity in future to allow a third party application to generate and serve the certificates from an arbitrary location

I have added a test case for a separated cluster here: https://github.com/ianmiell/shutit-openshift-cluster/tree/master/cluster_configs/test_multi_node_basic_cert_server