### PR TITLE
Allow passing custom arguments to `oc adm router` when deploying the hosted router

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,6 +51,7 @@ openshift3-shared-attributes: &SHARED
     claim:
       namespace: default
   registry_persistent_volume: registry-storage
+  openshift_hosted_router_options: '--expose-metrics'
   openshift_hosted_metrics_parameters:
     HAWKULAR_METRICS_HOSTNAME: metrics.10.0.2.15.nip.io
     METRIC_DURATION: "30"

--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -152,6 +152,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_hosted_manage_router']` -  Defaults to `true`.
 * `node['cookbook-openshift3']['openshift_hosted_router_selector']` -  Defaults to `region=infra`.
 * `node['cookbook-openshift3']['openshift_hosted_router_namespace']` -  Defaults to `default`.
+* `node['cookbook-openshift3']['openshift_hosted_router_options']` -  Defaults to `[]`.
 * `node['cookbook-openshift3']['openshift_hosted_manage_registry']` -  Defaults to `true`.
 * `node['cookbook-openshift3']['openshift_hosted_router_certfile']` - Defaults to `"#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.crt"`.
 * `node['cookbook-openshift3']['openshift_hosted_router_keyfile']` - Defaults to `"#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.key"`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,6 +160,7 @@ default['cookbook-openshift3']['openshift_node_read_only_port'] = nil # usually 
 default['cookbook-openshift3']['openshift_hosted_manage_router'] = true
 default['cookbook-openshift3']['openshift_hosted_router_selector'] = 'region=infra'
 default['cookbook-openshift3']['openshift_hosted_router_namespace'] = 'default'
+default['cookbook-openshift3']['openshift_hosted_router_options'] = []
 default['cookbook-openshift3']['openshift_hosted_router_certfile'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.crt"
 default['cookbook-openshift3']['openshift_hosted_router_keyfile'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-router.key"
 

--- a/providers/openshift_deploy_router.rb
+++ b/providers/openshift_deploy_router.rb
@@ -34,8 +34,9 @@ action :create do
     not_if 'oc get secret router-certs -n $namespace_router --no-headers'
   end
 
+  deploy_options = %w(--selector=${selector_router} -n ${namespace_router}) + Array(new_resource.deployer_options)
   execute 'Deploy Hosted Router' do
-    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router --selector=${selector_router} -n ${namespace_router} --config=admin.kubeconfig || true"
+    command "#{node['cookbook-openshift3']['openshift_common_client_binary']} adm router #{deploy_options.join(' ')} --config=admin.kubeconfig || true"
     environment(
       'selector_router' => node['cookbook-openshift3']['openshift_hosted_router_selector'],
       'namespace_router' => node['cookbook-openshift3']['openshift_hosted_router_namespace']

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -128,6 +128,7 @@ node_servers.reject { |h| h.key?('skip_run') }.each do |nodes|
 end
 
 openshift_deploy_router 'Deploy Router' do
+  deployer_options node['cookbook-openshift3']['openshift_hosted_router_options']
   only_if do
     node['cookbook-openshift3']['openshift_hosted_manage_router']
   end

--- a/resources/openshift_deploy_router.rb
+++ b/resources/openshift_deploy_router.rb
@@ -10,3 +10,5 @@ resource_name :openshift_deploy_router
 actions :create
 
 default_action :create
+
+attribute :deployer_options, kind_of: [String, Array], default: []

--- a/test/inspec/shared/22_feature_hosted_router_test.rb
+++ b/test/inspec/shared/22_feature_hosted_router_test.rb
@@ -15,3 +15,9 @@ describe command("oc get dc/router -n default --template '{{.spec.template.spec.
   its('exit_status') { should eq 0 }
   its('stdout') { should match(/region:infra/) }
 end
+
+# oc adm router was passed the custom option, resulting in metrics being exposed
+describe command(%[oc get dc/router -n default -o jsonpath='{ .spec.template.spec.containers[?(@.name == "metrics-exporter")].name }']) do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/metrics-exporter/) }
+end


### PR DESCRIPTION
This PR allows to pass custom arguments when deploying the hosted router with `oc adm router`.

My objective is to deploy the openshift hosted router with the prometheus metrics exposed, as documented in https://docs.openshift.com/container-platform/3.5/install_config/router/default_haproxy_router.html#exposing-the-router-metrics . For this, I need to inject the `--expose-metrics` (and eventually `--metrics-image`) options in the `oc adm router` command line arguments.

My proposal is to add a new attribute `node['cookbook-openshift3']['openshift_hosted_router_options']`, which defaults to empty and allows to define command line fragment that will be passed to `oc adm router` when this cookbook deploys the router.