### PR TITLE
Cookstyle fix

### DIFF
--- a/recipes/validate.rb
+++ b/recipes/validate.rb
@@ -22,7 +22,7 @@ if !node['cookbook-openshift3']['openshift_HA'] && node['cookbook-openshift3']['
 end
 
 if node['cookbook-openshift3']['openshift_hosted_cluster_metrics']
-  unless node['cookbook-openshift3']['openshift_metrics_cassandra_storage_types'].any? { |t| t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']) == 0 }
+  unless node['cookbook-openshift3']['openshift_metrics_cassandra_storage_types'].any? { |t| t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']).zero? }
     Chef::Application.fatal!('Key openshift_metrics_cassandra_storage_types is not valid. Please refer to the documentation for supprted types')
   end
 end


### PR DESCRIPTION
This PR fixes the following cookstyle offense:

```sh
$ cookstyle 
Inspecting 64 files
.........................C......................................

Offenses:

recipes/validate.rb:25:94: C: Use t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']).zero? instead of t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']) == 0.
  unless node['cookbook-openshift3']['openshift_metrics_cassandra_storage_types'].any? { |t| t.casecmp(node['cookbook-openshift3']['openshift_metrics_cassandra_storage_type']) == 0 }
                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

64 files inspected, 1 offense detected
```