### PR TITLE
Update CentOS version in .kitchen.yml to v7.4 (from v7.2)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,9 +19,9 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-7.2
+  - name: centos-7.4
     driver:
-      vm_hostname: origin-centos-72
+      vm_hostname: origin-centos-74
 
 openshift3-shared-attributes: &SHARED
   # uncomment to use experimental CentOS PaaS repository for integration tests
@@ -59,7 +59,7 @@ openshift3-shared-attributes: &SHARED
     USE_PERSISTENT_STORAGE: "false"
   master_servers: &SERVERS
    - ipaddress: 10.0.2.15
-     fqdn: origin-centos-72
+     fqdn: origin-centos-74
      labels: region=infra custom=label
      schedulable: false
   node_servers: *SERVERS

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Requirements
 
 ## Platform ##
 
-* Tested on Red Hat RHEL 7.2
-* Tested on Centos 7.2
+* Tested on Red Hat RHEL 7.4
+* Tested on Centos 7.4
 
 ## Openshift Version ##
 
@@ -27,7 +27,7 @@ Test Matrix
 
 | Platform   | OSE 3.6.0 | OSE 1.5.1 | OSE 1.4.1 | OSE 1.3.3 | OSE 1.2.2 |
 | --------   | --------- | --------- | --------- | --------- | --------- |
-| centos 7.2 | PASS      | PASS      | PASS      | PASS      | Not supported |
+| centos 7.4 | PASS      | PASS      | PASS      | PASS      | Not supported |
 
 Override Attributes
 ===================


### PR DESCRIPTION
This PR updates the CentOS version used in kitchen tests from 7.2 to 7.4 (current stable).