### PR TITLE
Fix regression with etcd host~ in standalone master-config

### DIFF
--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -68,19 +68,19 @@ etcdClientInfo:
 <%- end -%>
 <%- else -%>
   urls:
-    - https://<%= node['cookbook-openshift3']['openshift_common_api_hostname'] %>:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
+    - https://127.0.0.1:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
 <%- end -%>
 <% if node['cookbook-openshift3']['openshift_master_embedded_etcd'] == true %>
 etcdConfig:
-  address: <%= node['cookbook-openshift3']['openshift_common_api_hostname'] %>:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
-  peerAddress: <%= node['cookbook-openshift3']['openshift_common_api_hostname'] %>:7001
+  address: 127.0.0.1:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
+  peerAddress: 127.0.0.1:7001
   peerServingInfo:
-    bindAddress: <%= node['cookbook-openshift3']['openshift_master_bind_addr'] %>:7001
+    bindAddress: 127.0.0.1:7001
     certFile: etcd.server.crt
     clientCA: ca.crt
     keyFile: etcd.server.key
   servingInfo:
-    bindAddress: <%= node['cookbook-openshift3']['openshift_master_bind_addr'] %>:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
+    bindAddress: 127.0.0.1:<%= node['cookbook-openshift3']['openshift_master_etcd_port'] %>
     certFile: etcd.server.crt
     clientCA: ca.crt
     keyFile: etcd.server.key


### PR DESCRIPTION
This PR fixes a regression that I introduced 2 weeks ago (see https://github.com/IshentRas/cookbook-openshift3/blame/master/templates/default/master.yaml.erb#L71-L76 ).

The problem happens when origin-master is deployed in standalone mode, using the embedded etcd instance:
 - the etcdConfig is configured in /etc/origin/master/master-config.yml to point etcd client at `node['cookbook-openshift3']['openshift_common_api_hostname']` port 4001.
 - that openshift_common_api_hostname may not always resolve to the local machine; in the case of a legacy server, it resolved to an external ipaddress, on which is listening a proxy which handles traffic for ports 80 and 443 but NOT for the etcd ports 4001 and 7001
 - in that case, the origin-master service will refuse to boot because it cannot join the etcd servers (which are actually running on the same instance); see at the end of this PR for a diff of /etc/origin/master/master-config.yml showing the regression as I tried to apply the newest cookbook code.
 - note: in the kitchen VMs, the value of openshift_common_api_hostname does not point to a separate server, so the kitchen suites did not spot the issue.

The regression was here: https://github.com/IshentRas/cookbook-openshift3/commit/853ab863f2f48b8f880cc454e52cf634518e72e0#diff-8ec49e8e1533e397501dcbf4e2f9a8ccR68  . In the past, we pointed the etcd client to `node['cookbook-openshift3']['openshift_common_hostname']` which defaults to `node['fqdn']`. The etcd clients would find its server and all would be well.

This PR changes to point etcd clients to 127.0.0.1 in the standalone/embedded etcd case; after all, this is a standalone server, so there is no need to make etcd listen to any interface other than 127.0.0.1 (before, it would listen to 0.0.0.0, and the client would access through the IP of `node['fqdn']`). The new configuration should be more simple and more secure (no listening on too many network interfaces).

Chef-client diff showing the regression as I upgrade my server:
```
    * openshift_create_master[Create master configuration file] action create
    * template[/etc/origin/master/master-config.yaml] action create
      - update content in file /etc/origin/master/master-config.yaml from 13c7c9 to fd4e42
      --- /etc/origin/master/master-config.yaml	2017-11-02 08:08:55.748296496 +0000
      +++ /etc/origin/master/.chef-master-config20171102-7175-n3nfr2.yaml	2017-11-02 08:14:54.567785816 +0000
      @@ -30,11 +30,12 @@
       apiVersion: v1
       assetConfig:
         logoutURL: ""
      -  masterPublicURL:  https://openshift.mycluster.example.com:8443
      +  masterPublicURL: https://openshift.mycluster.example.com:8443
         publicURL: https://openshift.mycluster.example.com:8443/console/
         loggingPublicURL: https://kibana.mycluster.example.com
         servingInfo:
           bindAddress: 0.0.0.0:8443
      +    bindNetwork: tcp4
           certFile: master.server.crt
           clientCA: ""
           keyFile: master.server.key
      @@ -42,17 +43,15 @@
           requestTimeoutSeconds: 0
       auditConfig:
         enabled: false
      -controllers: '*'
       controllerConfig:
         serviceServingCert:
           signer:
             certFile: service-signer.crt
             keyFile: service-signer.key
      +controllers: '*'
       corsAllowedOrigins:
         - 127.0.0.1
         - localhost
      -  - mycluster-master
      -  - mycluster.example.com
         - openshift.mycluster.example.com
         - openshift
         - openshift.default
      @@ -72,10 +71,10 @@
         certFile: master.etcd-client.crt
         keyFile: master.etcd-client.key
         urls:
      -    - https://mycluster-master:4001
      +    - https://mycluster.example.com:4001
       etcdConfig:
      -  address: mycluster-master:4001
      -  peerAddress: mycluster-master:7001
      +  address: mycluster.example.com:4001
      +  peerAddress: mycluster.example.com:7001
         peerServingInfo:
           bindAddress: 0.0.0.0:7001
           certFile: etcd.server.crt
      @@ -120,6 +119,7 @@
         proxyClientInfo:
           certFile: master.proxy-client.crt
           keyFile: master.proxy-client.key
      +  schedulerArguments:
         schedulerConfigFile: /etc/origin/master/scheduler.json
         servicesNodePortRange: ""
         servicesSubnet: 172.30.0.0/16
      @@ -140,9 +140,12 @@
       masterPublicURL: https://openshift.mycluster.example.com:8443
       networkConfig:
         clusterNetworkCIDR: 10.128.0.0/14
      -  serviceNetworkCIDR: 172.30.0.0/16
         hostSubnetLength: 9
         networkPluginName: redhat/openshift-ovs-subnet
      +# serviceNetworkCIDR must match kubernetesMasterConfig.servicesSubnet
      +  serviceNetworkCIDR: 172.30.0.0/16
      +  externalIPNetworkCIDRs:
      +  - 0.0.0.0/0
       oauthConfig:
         assetPublicURL: https://openshift.mycluster.example.com:8443/console/
         grantConfig:
      @@ -171,16 +174,16 @@
         openshiftSharedResourcesNamespace: openshift
       projectConfig:
         defaultNodeSelector: "region=primary"
      -  projectRequestMessage: 
      -  projectRequestTemplate: 
      +  projectRequestMessage: ""
      +  projectRequestTemplate: ""
         securityAllocator:
           mcsAllocatorRange: "s0:/2"
           mcsLabelsPerProject: 5
      -    uidAllocatorRange: 1000000000-1999999999/10000
      +    uidAllocatorRange: "1000000000-1999999999/10000"
       routingConfig:
      -  subdomain: mycluster.example.com
      +  subdomain: "mycluster.example.com"
       serviceAccountConfig:
      -  limitSecretReferences: false
      +  limitSecretReferences: False
         managedNames:
         - default
         - builder
      - restore selinux security context
  Recipe: cookbook-openshift3::default
    * ruby_block[Restart Master] action run
      - execute the ruby block Restart Master
  
Recipe: cookbook-openshift3::master_standalone
  * service[origin-master] action start
    
    ================================================================================
    Error executing action `start` on resource 'service[origin-master]'
    ================================================================================
    
    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of /usr/bin/systemctl --system start origin-master ----
    STDOUT: 
    STDERR: Job for origin-master.service failed because the control process exited with error code. See "systemctl status origin-master.service" and "journalctl -xe" for details.
    ---- End output of /usr/bin/systemctl --system start origin-master ----
    Ran /usr/bin/systemctl --system start origin-master returned 1
