### PR TITLE
Event retention

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -148,6 +148,7 @@ default['cookbook-openshift3']['openshift_master_ca_certificate'] = { 'data_bag_
 default['cookbook-openshift3']['openshift_master_named_certificates'] = %w()
 default['cookbook-openshift3']['openshift_master_scheduler_conf'] = "#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json"
 default['cookbook-openshift3']['openshift_master_managed_names_additional'] = %w()
+default['cookbook-openshift3']['openshift_master_retain_events'] = nil
 default['cookbook-openshift3']['openshift_node_config_dir'] = "#{node['cookbook-openshift3']['openshift_common_node_dir']}/node"
 default['cookbook-openshift3']['openshift_node_config_file'] = "#{node['cookbook-openshift3']['openshift_node_config_dir']}/node-config.yaml"
 default['cookbook-openshift3']['openshift_node_debug_level'] = '2'

--- a/templates/default/master.yaml.erb
+++ b/templates/default/master.yaml.erb
@@ -122,6 +122,10 @@ kubernetesMasterConfig:
     storage-media-type:
     - application/vnd.kubernetes.protobuf
 <%- end -%>
+<% if node['cookbook-openshift3']['openshift_master_retain_events'] %>
+    event-ttl:
+    - "<%= node['cookbook-openshift3']['openshift_master_retain_events'] %>"    
+<%- end -%>
 <%- end -%>
   controllerArguments: 
 <% if node['cookbook-openshift3']['openshift_cloud_provider'] %>


### PR DESCRIPTION
Add possibilty to give event-ttl argument for api server.
Our ops team want the possibility to increase the retention period for events, e.g. 
    event-ttl:
    - "24h"

(default 1h0m0s)
