### PR TITLE
Fix cluster-native provisioning when common_api_hostname != common_public_hostname

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ openshift3-shared-attributes: &SHARED
   #    baseurl: "http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin/"
   #    gpgcheck: false
   # attention: if using http proxies, make sure that '10.0.2.15.nip.io' is whitelisted in $no_proxy!
+  openshift_common_public_hostname: openshift.10.0.2.15.nip.io
   openshift_common_api_hostname: 10.0.2.15.nip.io
   openshift_master_router_subdomain: cloudapps.10.0.2.15.nip.io
   openshift_master_metrics_public_url: metrics.10.0.2.15.nip.io

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -127,7 +127,7 @@ if certificate_server['fqdn'] == node['fqdn']
 
   execute "Create the master certificates for #{master_servers.first['fqdn']}" do
     command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-master-certs \
-            --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [master_servers.first['ipaddress'], master_servers.first['fqdn']]).uniq.join(',')} \
+            --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [master_servers.first['ipaddress'], master_servers.first['fqdn'], node['cookbook-openshift3']['openshift_common_api_hostname']]).uniq.join(',')} \
             --master=#{node['cookbook-openshift3']['openshift_master_api_url']} \
             --public-master=#{node['cookbook-openshift3']['openshift_master_public_api_url']} \
             --cert-dir=#{node['cookbook-openshift3']['openshift_master_config_dir']} --overwrite=false"
@@ -177,7 +177,7 @@ if certificate_server['fqdn'] == node['fqdn']
 
     execute "Create the master server certificates for #{peer_server['fqdn']}" do
       command "#{node['cookbook-openshift3']['openshift_common_admin_binary']} ca create-server-cert \
-              --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [peer_server['ipaddress'], peer_server['fqdn']]).uniq.join(',')} \
+              --hostnames=#{(node['cookbook-openshift3']['erb_corsAllowedOrigins'] + [peer_server['ipaddress'], peer_server['fqdn'], node['cookbook-openshift3']['openshift_common_api_hostname']]).uniq.join(',')} \
               --cert=#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/master.server.crt \
               --key=#{node['cookbook-openshift3']['master_generated_certs_dir']}/openshift-#{peer_server['fqdn']}/master.server.key \
               --signer-cert=#{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt \

--- a/test/inspec/shared/11_functioning_openshift_test.rb
+++ b/test/inspec/shared/11_functioning_openshift_test.rb
@@ -62,3 +62,11 @@ describe command('host 172.30.0.1') do
   its('exit_status') { should eq 0 }
   its('stdout') { should include('kubernetes.default.svc.cluster.local') }
 end
+
+# in case the common_public_hostname and common_api_hostname are different,
+# then the master certificate should list both hostnames in its Subject Alternative Name.
+describe command('openssl x509 -in /etc/origin/master/master.server.crt -text | grep -A1 "Subject Alternative Name"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should include('DNS:openshift.10.0.2.15.nip.io') } # public hostname
+  its('stdout') { should include('DNS:10.0.2.15.nip.io') }           # api hostname
+end


### PR DESCRIPTION
This PR fixes provisioning the cluster in HA mode (cluster-native) when both `node['cookbook-openshift3']['openshift_common_api_hostname']` and `node['cookbook-openshift3']['openshift_common_public_hostname']` are provided and they have a different value.

Why have a different value for api and public hostname?
 - the public hostname is associated with a public SSL certificate (signed by a public CA), so that clients can use the openshift console without having to accept a self-signed certificate in their browser
 - the api hostname is for internal use and uses certificates signed by the openshift CA

In the real world, I configure my attributes like this:
```json
    "cookbook-openshift3": {
      "openshift_HA": true,
      "openshift_cluster_name": "mycluster.example.com",
      "master_servers": [ ... ],
      "etcd_servers": [ ... ],
      "node_servers": [ ... ]
      "openshift_common_public_hostname": "openshift.mycluster.example.com",  # public wildcard SSL cert
      "openshift_common_api_hostname": "mycluster.example.com",                     # internal self-signed SSL cert
      "openshift_master_router_subdomain": "mycluster.example.com",                 # public wildcard SSL cert
      "openshift_master_logging_public_url": "kibana.mycluster.example.com",       # public wildcard SSL cert
      ....
    }
```

This use-case used to work, but has been broken on master shortly after the release of v1.10.64 [here](https://github.com/IshentRas/cookbook-openshift3/commit/8894372188e7f8ca85f7f6d78b0882ba8861e351#diff-25e5d4a4446ae12a0d6f1162b6160375R183). No new release has been done yet, so the broken commit only lives on master.

I found about the issue when trying to provision an OSE v3.6.1 cluster using code from current master (since no new release has been done yet). When api and public hostnames are different provisioning fails: the loop which waits for API server to be available never succeeds because of certificate validation issues and chef fails with the following message:

```
           ================================================================================
           Error executing action `run` on resource 'execute[Wait for API to become available]'
           ================================================================================
           
           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '1'
           ---- Begin output of [[ $(curl --silent https://10.0.2.15.nip.io:8443/healthz/ready --cacert /etc/origin/master/ca.crt --cacert /etc/origin/master/ca-bundle.crt) =~ "ok" ]] ----
           STDOUT: 
           STDERR: 
           ---- End output of [[ $(curl --silent https://10.0.2.15.nip.io:8443/healthz/ready --cacert /etc/origin/master/ca.crt --cacert /etc/origin/master/ca-bundle.crt) =~ "ok" ]] ----
           Ran [[ $(curl --silent https://10.0.2.15.nip.io:8443/healthz/ready --cacert /etc/origin/master/ca.crt --cacert /etc/origin/master/ca-bundle.crt) =~ "ok" ]] returned 1
```

The reason is the api hostname not being listed in the /etc/origin/master/master.server.crt x509 Subject Alternative Name. In the standalone code, that SAN is listed and provisioning works, but not in the cluster-native case.

This PR fixes the cluster-native case and adds an inspec example to prevent regression in both cluster-native and standalone cases.