### PR TITLE
Add the new openshift_master_retain_events attribute in attribute-cookbook.md

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -139,6 +139,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_master_named_certificates']` -  Defaults to `%w()`.
 * `node['cookbook-openshift3']['openshift_master_scheduler_conf']` -  Defaults to `#{node['cookbook-openshift3']['openshift_master_config_dir']}/scheduler.json`.
 * `node['cookbook-openshift3']['openshift_master_managed_names_additional']` -  Defaults to `%w()`.
+* `node['cookbook-openshift3']['openshift_master_retain_events']` default to `nil`.
 * `node['cookbook-openshift3']['openshift_node_config_dir']` -  Defaults to `#{node['cookbook-openshift3']['openshift_common_node_dir']}/node`.
 * `node['cookbook-openshift3']['openshift_node_config_file']` -  Defaults to `#{node['cookbook-openshift3']['openshift_node_config_dir']}/node-config.yaml`.
 * `node['cookbook-openshift3']['openshift_node_min_tls_version']` -  Defaults to `nil`.


### PR DESCRIPTION
This PR follows up to #176 and documents the new attribute.