### PR TITLE
Update default OSE v3.6 version to v3.6.1 (from v3.6.0)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['cookbook-openshift3']['ose_version'] = nil
 default['cookbook-openshift3']['persistent_storage'] = []
 default['cookbook-openshift3']['openshift_deployment_type'] = 'enterprise'
 default['cookbook-openshift3']['ose_major_version'] = '3.6'
-default['cookbook-openshift3']['openshift_docker_image_version'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.6' : 'v3.6.0'
+default['cookbook-openshift3']['openshift_docker_image_version'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.6' : 'v3.6.1'
 default['cookbook-openshift3']['deploy_containerized'] = false
 default['cookbook-openshift3']['deploy_example'] = false
 default['cookbook-openshift3']['deploy_dnsmasq'] = true

--- a/attributes/metrics.rb
+++ b/attributes/metrics.rb
@@ -35,7 +35,7 @@ default['cookbook-openshift3']['openshift_metrics_heapster_requests_cpu'] = ''
 default['cookbook-openshift3']['openshift_metrics_heapster_requests_memory'] = '0.9375G'
 default['cookbook-openshift3']['openshift_metrics_heapster_standalone'] = false
 default['cookbook-openshift3']['openshift_metrics_image_prefix'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'registry.access.redhat.com/openshift3/' : 'docker.io/openshift/origin-'
-default['cookbook-openshift3']['openshift_metrics_image_version'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.6' : 'v3.6.0'
+default['cookbook-openshift3']['openshift_metrics_image_version'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.6' : 'v3.6.1'
 default['cookbook-openshift3']['openshift_metrics_install_metrics'] = true
 default['cookbook-openshift3']['openshift_metrics_master_url'] = 'https://kubernetes.default.svc'
 default['cookbook-openshift3']['openshift_metrics_node_id'] = 'nodename'

--- a/test/roles/openshift3-base-ose36.json
+++ b/test/roles/openshift3-base-ose36.json
@@ -9,7 +9,7 @@
     "cookbook-openshift3": {
       "openshift_deployment_type": "origin",
       "ose_major_version": "3.6",
-      "ose_version": "3.6.0-1.0.c4dd4cf",
+      "ose_version": "3.6.1-1.0.008f2d5",
       "openshift_common_portal_net": "172.30.0.0/16",
       "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
       "openshift_master_sdn_host_subnet_length": 9,
@@ -17,7 +17,7 @@
       "openshift_hosted_manage_registry": true,
       "openshift_hosted_cluster_metrics": true,
       "deploy_example": false,
-      "openshift_metrics_image_version": "v3.6.0"
+      "openshift_metrics_image_version": "v3.6.1"
     }
   },
   "chef_type": "role",


### PR DESCRIPTION
Some more gardening for this cookbook: update default OSE v3.6 version to v3.6.1 (current stable). I'm already deploying this version successfully, so may as well update the cookbook defaults.