### PR TITLE
raise -> return

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -111,7 +111,7 @@ ruby_block 'Change HTTPD port xfer' do
     # if #search_file_replace_line is invoked with a multiline Regexp.
     class MyFileEdit
       def initialize(filepath)
-        raise ArgumentError, "File '#{filepath}' does not exist" unless File.exist?(filepath)
+        return ArgumentError, "File '#{filepath}' does not exist" unless File.exist?(filepath)
         @contents = File.open(filepath, &:read)
         @original_pathname = filepath
         @changes = false


### PR DESCRIPTION
This was flagged by our internal foodcritic.

If there's a reason we use raise instead of return, please reject.