### PR TITLE
Add kitchen test for Openshift Origin v3.7.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -66,6 +66,32 @@ openshift3-shared-attributes: &SHARED
   node_servers: *SERVERS
 
 suites:
+  - name: standalone-ose37
+    run_list:
+      - role[openshift3-base-ose37]
+    verifier:
+      inspec_tests:
+        - test/inspec/standalone
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: false
+
+  - name: cluster-native-ose37
+    run_list:
+      - role[openshift3-base-ose37]
+    verifier:
+      inspec_tests:
+        - test/inspec/cluster-native
+        - test/inspec/shared
+    attributes:
+      cookbook-openshift3:
+        << : *SHARED
+        openshift_HA: true
+        openshift_cluster_name: test-cluster.domain.local
+        etcd_servers: *SERVERS
+
   - name: standalone-ose36
     run_list:
       - role[openshift3-base-ose36]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 
 * Support OSE version from 3.3+
 * Support Origin version from 1.3+
-* Default the installation to 3.6
+* Default the installation to 3.7
 
 **Highly recommended**: explicitly set `node['cookbook-openshift3']['ose_version']`, `node['cookbook-openshift3']['ose_major_version']`
 and ideally `node['cookbook-openshift3']['docker_version']` to be safe when a major version is released on the
@@ -25,9 +25,9 @@ in your openshift3 role or environment.
 Test Matrix
 ===========
 
-| Platform   | OSE 3.6.0 | OSE 1.5.1 | OSE 1.4.1 | OSE 1.3.3 | OSE 1.2.2 |
-| --------   | --------- | --------- | --------- | --------- | --------- |
-| centos 7.4 | PASS      | PASS      | PASS      | PASS      | Not supported |
+| Platform   | OSE 3.7.0 | OSE 3.6.0 | OSE 1.5.1 | OSE 1.4.1 | OSE 1.3.3 | OSE 1.2.2 |
+| --------   | --------- | --------- | --------- | --------- | --------- | --------- |
+| centos 7.4 | PASS      | PASS      | PASS      | PASS      | PASS      | Not supported |
 
 Override Attributes
 ===================

--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -34,7 +34,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['ose_version']` -  Defaults to `nil`.
 * `node['cookbook-openshift3']['persistent_storage']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['openshift_deployment_type']` -  Defaults to `enterprise`.
-* `node['cookbook-openshift3']['ose_major_version']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? '3.4' : '1.4`.
+* `node['cookbook-openshift3']['ose_major_version']` -  Defaults to `'3.7'`.
 * `node['cookbook-openshift3']['deploy_containerized']` -  Defaults to `false`.
 * `node['cookbook-openshift3']['deploy_example']` -  Defaults to `false`.
 * `node['cookbook-openshift3']['deploy_dnsmasq']` -  Defaults to `true`.
@@ -86,7 +86,7 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_docker_add_registry_arg']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['openshift_docker_block_registry_arg']` -  Defaults to `[ ... ]`.
 * `node['cookbook-openshift3']['openshift_docker_insecure_registries']` -  Defaults to `node['cookbook-openshift3']['openshift_docker_add_registry_arg'].empty? ? [node['cookbook-openshift3']['openshift_common_portal_net']] : [node['cookbook-openshift3']['openshift_common_portal_net']] + node['cookbook-openshift3']['openshift_docker_insecure_registry_arg']`.
-* `node['cookbook-openshift3']['openshift_docker_image_version']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.4' : 'v1.4`.
+* `node['cookbook-openshift3']['openshift_docker_image_version']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'v3.7' : 'v3.7.0`.
 * `node['cookbook-openshift3']['openshift_docker_cli_image']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'openshift3/ose' : 'openshift/origin`.
 * `node['cookbook-openshift3']['openshift_docker_master_image']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'openshift3/ose' : 'openshift/origin`.
 * `node['cookbook-openshift3']['openshift_docker_node_image']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'openshift3/node' : 'openshift/node`.

--- a/test/roles/openshift3-base-ose37.json
+++ b/test/roles/openshift3-base-ose37.json
@@ -1,0 +1,27 @@
+{
+  "name": "openshift3-base",
+  "description": "Openshift3 Common Base Role",
+  "json_class": "Chef::Role",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+    "cookbook-openshift3": {
+      "openshift_deployment_type": "origin",
+      "ose_major_version": "3.7",
+      "ose_version": "3.7.0-1.0.7ed6862",
+      "openshift_common_portal_net": "172.30.0.0/16",
+      "openshift_master_sdn_cluster_network_cidr": "10.128.0.0/14",
+      "openshift_master_sdn_host_subnet_length": 9,
+      "openshift_hosted_manage_router": true,
+      "openshift_hosted_manage_registry": true,
+      "openshift_hosted_cluster_metrics": true,
+      "deploy_example": false,
+      "openshift_metrics_image_version": "v3.7.0"
+    }
+  },
+  "chef_type": "role",
+  "run_list": [
+    "recipe[cookbook-openshift3::default]"
+  ]
+}


### PR DESCRIPTION
This PR enables kitchen tests for OSE v3.7.x.
It also updates README.md and attribute-cookbook.md with OSE v3.7 as default version deployed by the cookbook.