### PR TITLE
Support for http_proxy, https_proxy and no_proxy

### DIFF
--- a/attribute-cookbook.md
+++ b/attribute-cookbook.md
@@ -60,6 +60,9 @@ Installs/Configures Openshift 3.x (>= 3.2)
 * `node['cookbook-openshift3']['openshift_service_type']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? 'atomic-openshift' : 'origin`.
 * `node['cookbook-openshift3']['registry_persistent_volume']` -  Defaults to ``.
 * `node['cookbook-openshift3']['yum_repositories']` -  Defaults to `node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/', 'gpgcheck' => false }]`.
+* `node['cookbook-openshift3']['openshift_http_proxy']` -  Defaults to `""`.
+* `node['cookbook-openshift3']['openshift_https_proxy']` -  Defaults to `""`.
+* `node['cookbook-openshift3']['openshift_no_proxy']` -  Defaults to `""`.
 * `node['cookbook-openshift3']['openshift_data_dir']` -  Defaults to `/var/lib/origin`.
 * `node['cookbook-openshift3']['openshift_common_base_dir']` -  Defaults to `/etc/origin`.
 * `node['cookbook-openshift3']['openshift_common_master_dir']` -  Defaults to `/etc/origin`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,10 @@ default['cookbook-openshift3']['openshift_service_type'] = node['cookbook-opensh
 default['cookbook-openshift3']['registry_persistent_volume'] = ''
 default['cookbook-openshift3']['yum_repositories'] = node['cookbook-openshift3']['openshift_deployment_type'] =~ /enterprise/ ? %w() : [{ 'name' => 'centos-openshift-origin13', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin13/', 'gpgcheck' => false }, { 'name' => 'centos-openshift-origin14', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin14/', 'gpgcheck' => false }, { 'name' => 'centos-openshift-origin15', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin15/', 'gpgcheck' => false }, { 'name' => 'centos-openshift-origin36', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin36/', 'gpgcheck' => false }, { 'name' => 'centos-openshift-origin37', 'baseurl' => 'http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin37/', 'gpgcheck' => false }]
 
+default['cookbook-openshift3']['openshift_http_proxy'] = ''
+default['cookbook-openshift3']['openshift_https_proxy'] = ''
+default['cookbook-openshift3']['openshift_no_proxy'] = ''
+
 default['cookbook-openshift3']['openshift_data_dir'] = '/var/lib/origin'
 default['cookbook-openshift3']['openshift_common_base_dir'] = '/etc/origin'
 default['cookbook-openshift3']['openshift_common_master_dir'] = '/etc/origin'

--- a/templates/default/service_docker.sysconfig.erb
+++ b/templates/default/service_docker.sysconfig.erb
@@ -42,3 +42,16 @@ BLOCK_REGISTRY='--block-registry <%= node['cookbook-openshift3']['openshift_dock
 # Controls the /etc/cron.daily/docker-logrotate cron job status.
 # To disable, uncomment the line below.
 # LOGROTATE=false
+<% unless node['cookbook-openshift3']['openshift_http_proxy'].empty? && node['cookbook-openshift3']['openshift_https_proxy'].empty? && node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+<% unless node['cookbook-openshift3']['openshift_http_proxy'].empty? -%>
+HTTP_PROXY="<%= node['cookbook-openshift3']['openshift_http_proxy'] %>"
+<% end %>
+<% unless node['cookbook-openshift3']['openshift_https_proxy'].empty? -%>
+HTTPS_PROXY="<%= node['cookbook-openshift3']['openshift_https_proxy'] %>"
+<% end %>
+<% unless node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
+NO_PROXY="<%= node['cookbook-openshift3']['openshift_no_proxy'] %>"
+<% end %>
+<% end -%>

--- a/templates/default/service_master-api.sysconfig.erb
+++ b/templates/default/service_master-api.sysconfig.erb
@@ -15,6 +15,26 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 # Proxy configuration
 # Origin uses standard HTTP_PROXY environment variables. Be sure to set
 # NO_PROXY for your master
+<% if node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
 #NO_PROXY=master.example.com
+<% else -%>
+NO_PROXY=<%= [
+  node['cookbook-openshift3']['openshift_no_proxy'].split(','),
+  node['cookbook-openshift3']['openshift_common_api_hostname'],
+  node['cookbook-openshift3']['master_servers'].map { |server| server['fqdn'] },
+  node['cookbook-openshift3']['node_servers'].map { |server| server['fqdn'] },
+  ".#{node['cookbook-openshift3']['osn_cluster_dns_domain']}",
+  node['cookbook-openshift3']['openshift_common_portal_net'],
+  node['cookbook-openshift3']['openshift_master_sdn_cluster_network_cidr']
+].flatten.uniq.join(',') %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_http_proxy'].empty? -%>
 #HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTP_PROXY=<%= node['cookbook-openshift3']['openshift_http_proxy'] %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_https_proxy'].empty? -%>
 #HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTPS_PROXY=<%= node['cookbook-openshift3']['openshift_https_proxy'] %>
+<% end %>

--- a/templates/default/service_master-controllers.sysconfig.erb
+++ b/templates/default/service_master-controllers.sysconfig.erb
@@ -15,6 +15,26 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 # Proxy configuration
 # Origin uses standard HTTP_PROXY environment variables. Be sure to set
 # NO_PROXY for your master
+<% if node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
 #NO_PROXY=master.example.com
+<% else -%>
+NO_PROXY=<%= [
+  node['cookbook-openshift3']['openshift_no_proxy'].split(','),
+  node['cookbook-openshift3']['openshift_common_api_hostname'],
+  node['cookbook-openshift3']['master_servers'].map { |server| server['fqdn'] },
+  node['cookbook-openshift3']['node_servers'].map { |server| server['fqdn'] },
+  ".#{node['cookbook-openshift3']['osn_cluster_dns_domain']}",
+  node['cookbook-openshift3']['openshift_common_portal_net'],
+  node['cookbook-openshift3']['openshift_master_sdn_cluster_network_cidr']
+].flatten.uniq.join(',') %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_http_proxy'].empty? -%>
 #HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTP_PROXY=<%= node['cookbook-openshift3']['openshift_http_proxy'] %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_https_proxy'].empty? -%>
 #HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTPS_PROXY=<%= node['cookbook-openshift3']['openshift_https_proxy'] %>
+<% end %>

--- a/templates/default/service_master.sysconfig.erb
+++ b/templates/default/service_master.sysconfig.erb
@@ -15,6 +15,26 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 # Proxy configuration
 # Origin uses standard HTTP_PROXY environment variables. Be sure to set
 # NO_PROXY for your master
+<% if node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
 #NO_PROXY=master.example.com
+<% else -%>
+NO_PROXY=<%= [
+  node['cookbook-openshift3']['openshift_no_proxy'].split(','),
+  node['cookbook-openshift3']['openshift_common_api_hostname'],
+  node['cookbook-openshift3']['master_servers'].map { |server| server['fqdn'] },
+  node['cookbook-openshift3']['node_servers'].map { |server| server['fqdn'] },
+  ".#{node['cookbook-openshift3']['osn_cluster_dns_domain']}",
+  node['cookbook-openshift3']['openshift_common_portal_net'],
+  node['cookbook-openshift3']['openshift_master_sdn_cluster_network_cidr']
+].flatten.uniq.join(',') %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_http_proxy'].empty? -%>
 #HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTP_PROXY=<%= node['cookbook-openshift3']['openshift_http_proxy'] %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_https_proxy'].empty? -%>
 #HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTPS_PROXY=<%= node['cookbook-openshift3']['openshift_https_proxy'] %>
+<% end %>

--- a/templates/default/service_node.sysconfig.erb
+++ b/templates/default/service_node.sysconfig.erb
@@ -25,6 +25,26 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 # Proxy configuration
 # Origin uses standard HTTP_PROXY environment variables. Be sure to set
 # NO_PROXY for your master
+<% if node['cookbook-openshift3']['openshift_no_proxy'].empty? -%>
 #NO_PROXY=master.example.com
+<% else -%>
+NO_PROXY=<%= [
+  node['cookbook-openshift3']['openshift_no_proxy'].split(','),
+  node['cookbook-openshift3']['openshift_common_api_hostname'],
+  node['cookbook-openshift3']['master_servers'].map { |server| server['fqdn'] },
+  node['cookbook-openshift3']['node_servers'].map { |server| server['fqdn'] },
+  ".#{node['cookbook-openshift3']['osn_cluster_dns_domain']}",
+  node['cookbook-openshift3']['openshift_common_portal_net'],
+  node['cookbook-openshift3']['openshift_master_sdn_cluster_network_cidr']
+].flatten.uniq.join(',') %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_http_proxy'].empty? -%>
 #HTTP_PROXY=http://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTP_PROXY=<%= node['cookbook-openshift3']['openshift_http_proxy'] %>
+<% end %>
+<% if node['cookbook-openshift3']['openshift_https_proxy'].empty? -%>
 #HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
+<% else -%>
+HTTPS_PROXY=<%= node['cookbook-openshift3']['openshift_https_proxy'] %>
+<% end %>


### PR DESCRIPTION
This PR adds support for deploying openshift on environment where outgoing http/https traffic must go through a proxy. Without it, even if we managed to install openshift, we still would not be able to pull docker images from external registries for example.

Official documentation is here: https://docs.openshift.org/latest/install_config/install/advanced_install.html#advanced-install-configuring-global-proxy  . The documented attributes are used by the openshift-ansible playbook to do the dirty work.

The new attributes are:
 -  `node['cookbook-openshift3']['openshift_http_proxy']`
 - `node['cookbook-openshift3']['openshift_https_proxy']`
 - `node['cookbook-openshift3']['openshift_no_proxy']`
All three default to empty string.

When the attributes are non empty, the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables are added to the following files:
 - /etc/sysconfig/docker
 - /etc/origin/master/master-config.yaml
 - /etc/origin/node/node-config.yaml
Additionally, the openshift version of `NO_PROXY` environment variable is augmented with the openshift master and node hostnames, with the openshift SDN and portal CIDRs etc, to allow the different components to communicate directly (this is what the ansible playbook does when `openshift_generate_no_proxy_hosts=True`, which is the default).

There are still some unclear points that could be improved by code review:
 - how to allow the docker daemon to pull from the hosted docker-registry (if enabled) if the ipaddress of the hosted docker registry is not known at deployment time (see https://github.com/openshift/openshift-ansible/issues/1919 ; ironically, it was me who reported years back that docker does not understand CIDRs in the no_proxy environment variables)
 - I'm not sure if I added enough exceptions in the openshift master no_proxy (I'm unfamiliar with the ansible playbook)