### PR TITLE
Change dnsmasq Requires to Wants

### DIFF
--- a/templates/default/service_node-containerized.service.erb
+++ b/templates/default/service_node-containerized.service.erb
@@ -13,7 +13,7 @@ Wants=<%= node['cookbook-openshift3']['openshift_service_type'] %>-master.servic
 Requires=<%= node['cookbook-openshift3']['openshift_service_type'] %>-node-dep.service
 After=<%= node['cookbook-openshift3']['openshift_service_type'] %>-node-dep.service
 <% if @ose_major_version.split('.')[1].to_i >= 6 %>
-Requires=dnsmasq.service
+Wants=dnsmasq.service
 After=dnsmasq.service
 <%- end %>
 

--- a/templates/default/service_node.service.erb
+++ b/templates/default/service_node.service.erb
@@ -6,7 +6,7 @@ After=ovsdb-server.service
 After=ovs-vswitchd.service
 Wants=docker.service
 Documentation=https://github.com/openshift/origin
-Requires=dnsmasq.service
+Wants=dnsmasq.service
 After=dnsmasq.service
 
 [Service]


### PR DESCRIPTION
This PR is straight port of https://github.com/openshift/openshift-ansible/pull/6843 which fixes https://bugzilla.redhat.com/show_bug.cgi?id=1532960

In short: if the dnsmasq service is restarted on the host, then origin-node service is also restarted (there should be no need IMO). I had noticed the problem a few weeks back but someone already wrote a patch and got it merged in the openshift-ansible playbook, so I do the same on this cookbook.