### PR TITLE
Test openshift_hosted_router_options with --stats-password (compatible with all OSE versions)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -52,7 +52,7 @@ openshift3-shared-attributes: &SHARED
     claim:
       namespace: default
   registry_persistent_volume: registry-storage
-  openshift_hosted_router_options: '--expose-metrics --metrics-image=prom/haproxy-exporter:v0.7.1'
+  openshift_hosted_router_options: '--stats-password=xyzzy'
   openshift_hosted_metrics_parameters:
     HAWKULAR_METRICS_HOSTNAME: metrics.10.0.2.15.nip.io
     METRIC_DURATION: "30"

--- a/test/inspec/shared/22_feature_hosted_router_test.rb
+++ b/test/inspec/shared/22_feature_hosted_router_test.rb
@@ -16,8 +16,8 @@ describe command("oc get dc/router -n default --template '{{.spec.template.spec.
   its('stdout') { should match(/region:infra/) }
 end
 
-# oc adm router was passed the custom option, resulting in metrics being exposed
-describe command(%[oc get dc/router -n default -o jsonpath='{ .spec.template.spec.containers[?(@.name == "metrics-exporter")].name }']) do
+# oc adm router was passed the custom option, resulting in a custom password being set in the DC
+describe command(%[oc get dc/router -n default -o jsonpath='{ .spec.template.spec.containers[*].env[?(@.name=="STATS_PASSWORD")].value }']) do
   its('exit_status') { should eq 0 }
-  its('stdout') { should match(/metrics-exporter/) }
+  its('stdout') { should match(/xyzzy/) }
 end


### PR DESCRIPTION
This PR changes the way we test that `node['cookbook-openshift3']['openshift_hosted_router_options']` attribute was properly passed to `oc adm router`.

We used to pass `--expose-metrics` but custom metrics options were removed in OSE v3.10.
Instead, we now use the `--stats-password` option which is supported by every OSE version.