### PR TITLE
Make SWAP disabling on nodes optional (but enabled by default).

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -194,6 +194,7 @@ default['cookbook-openshift3']['openshift_node_kubelet_args_custom'] = {}
 default['cookbook-openshift3']['openshift_node_iptables_sync_period'] = '30s'
 default['cookbook-openshift3']['openshift_node_port_range'] = ''
 default['cookbook-openshift3']['openshift_node_sdn_mtu_sdn'] = '1450'
+default['cookbook-openshift3']['openshift_node_disable_swap_on_host'] = true
 # Deprecated options (Use openshift_node_kubelet_args_custom instead)
 default['cookbook-openshift3']['openshift_node_max_pod'] = ''
 default['cookbook-openshift3']['openshift_node_image_config_latest'] = false

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -25,7 +25,8 @@ if is_node_server
     block do
       server_info.turn_off_swap
     end
-    only_if { ::File.readlines('/etc/fstab').grep(/(^[^#].*swap.*)\n/).any? }
+    not_if { ::File.readlines('/etc/fstab').grep(/(^[^#].*swap.*)\n/).none? }
+    only_if { node['cookbook-openshift3']['openshift_node_disable_swap_on_host'] }
   end
 
   file '/usr/local/etc/.firewall_node_additional.txt' do


### PR DESCRIPTION
This PR makes disabling the SWAP on nodes optional (but enabled by default).

Why leave swap enabled even if it makes origin node less reliable? On my workstation, I have limited memory availability yet I want to test multi VM clusters without having random pods inside get OOMKilled. With this PR I can set `node['cookbook-openshift3']['openshift_node_disable_swap_on_host'] = false` in my role attributes and be happy.