### PR TITLE
Poll /healthz/ready using openshift_master_loopback_api_url only

### DIFF
--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -220,7 +220,7 @@ execute 'Activate services for Master API on all masters' do
 end
 
 execute 'Wait for API to become available' do
-  command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+  command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
   retries 120
   retry_delay 1
 end

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -12,7 +12,7 @@ ose_major_version = node['cookbook-openshift3']['deploy_containerized'] == true 
 service_accounts = node['cookbook-openshift3']['openshift_common_service_accounts_additional'].any? ? node['cookbook-openshift3']['openshift_common_service_accounts'] + node['cookbook-openshift3']['openshift_common_service_accounts_additional'] : node['cookbook-openshift3']['openshift_common_service_accounts']
 
 execute 'Check Master API' do
-  command "[[ $(curl --silent #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+  command "[[ $(curl --silent #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
   retries 120
   retry_delay 1
 end

--- a/recipes/ng_nodes_certificates.rb
+++ b/recipes/ng_nodes_certificates.rb
@@ -23,7 +23,7 @@ else
 end
 
 execute 'Wait for API to become available' do
-  command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+  command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
   retries 150
   retry_delay 5
 end

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -290,7 +290,7 @@ if is_node_server
 
   execute 'Wait for API to become available before starting Node component' do
     command "[[ $(curl --silent --tlsv1.2 --max-time 2 ${MASTER_URL}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_node_config_dir']}/ca.crt) =~ \"ok\" ]]"
-    environment 'MASTER_URL' => node['cookbook-openshift3']['openshift_HA'] ? node['cookbook-openshift3']['openshift_master_api_url'] : "https://#{node['cookbook-openshift3']['openshift_common_api_hostname']}:#{node['cookbook-openshift3']['openshift_master_api_port']}"
+    environment 'MASTER_URL' => node['cookbook-openshift3']['openshift_master_api_url']
     retries 120
     retry_delay 1
     notifies :start, 'service[Restart Node]', :immediately unless node['cookbook-openshift3']['upgrade'] && node['cookbook-openshift3']['deploy_containerized']

--- a/recipes/upgrade_control_plane38_part1.rb
+++ b/recipes/upgrade_control_plane38_part1.rb
@@ -73,7 +73,7 @@ end
 if is_master_server && is_first_master
 
   execute 'Wait for API to be ready (3.8)' do
-    command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+    command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
     retries 120
     retry_delay 1
   end

--- a/recipes/upgrade_control_plane39_part1.rb
+++ b/recipes/upgrade_control_plane39_part1.rb
@@ -71,7 +71,7 @@ end
 if is_master_server && is_first_master
 
   execute 'Wait for API to be ready (3.9)' do
-    command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+    command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
     retries 120
     retry_delay 1
   end

--- a/resources/openshift_upgrade.rb
+++ b/resources/openshift_upgrade.rb
@@ -35,7 +35,7 @@ end
 
 action :reconcile_cluster_roles do
   execute 'Wait for API to be ready' do
-    command "[[ $(curl --silent #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+    command "[[ $(curl --silent #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
     retries 120
     retry_delay 1
   end


### PR DESCRIPTION
When upgrading a production cluster which uses a `node['cookbook-openshift3']['openshift_master_named_certificates']`, I noticed the code which poll (in different place) for master API being ready fail. This code was not present in version 1.0.6x of this cookbook so I only report it now.

The reason is that the polling code curls the public master API URL endpoint (which uses the named certificate) while specifying the internal kubernetes certificate as `--cacert`. When the public master API URL endpoint uses a certificate signed by a public CA (which is not the internal kubernetes certificate) then the readiness test fails and the chef run too.

Example broken code here: https://github.com/IshentRas/cookbook-openshift3/blob/master/recipes/master_cluster.rb#L222-L226

Proposed fix: always poll the master for readiness using the `node['cookbook-openshift3']['openshift_master_loopback_api_url']` endpoint (eg. https://localhost:8443). This endpoint should be valid on all master instances and always use a certificate signed by the kubernetes CA.

Broken curl output using the public master api URL with named certificate:
```
# curl -v --tlsv1.2 --max-time 2 https://openshift.example.com:8443/healthz/ready --cacert /etc/origin/master/ca.crt --cacert /etc/origin/master/ca-bundle.crt
* About to connect() to openshift.example.com port 8443 (#0)
*   Trying 172.17.0.35...
* Connected to openshift.example.com (172.17.0.35) port 8443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/origin/master/ca-bundle.crt
  CApath: none
* Server certificate:
*       subject: CN=*.example.com,OU=Domain Control Validated
*       start date: Mar 06 16:49:13 2017 GMT
*       expire date: Mar 06 16:49:13 2020 GMT
*       common name: *.example.com
*       issuer: CN=GlobalSign Domain Validation CA - SHA256 - G2,O=GlobalSign nv-sa,C=BE
* NSS error -8179 (SEC_ERROR_UNKNOWN_ISSUER)
* Peer's Certificate issuer is not recognized.
* Closing connection 0
curl: (60) Peer's Certificate issuer is not recognized.
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

Working curl output using the loopback master api URL with named certificate:
```
# curl -v --tlsv1.2 --max-time 2 https://localhost:8443/healthz/ready --cacert /etc/origin/master/ca.crt --cacert /etc/origin/master/ca-bundle.crt
* About to connect() to localhost port 8443 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/origin/master/ca-bundle.crt
  CApath: none
* NSS: client certificate not found (nickname not specified)
* SSL connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate:
*       subject: CN=127.0.0.1
*       start date: May 17 13:00:51 2017 GMT
*       expire date: May 17 13:00:52 2019 GMT
*       common name: 127.0.0.1
*       issuer: CN=openshift-signer@1489695758
> GET /healthz/ready HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8443
> Accept: */*
>
< HTTP/1.1 200 OK
< Cache-Control: no-store
< Date: Mon, 01 Oct 2018 08:09:44 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
ok
```