### PR TITLE
Allow configuring any option supported by docker-storage-setup

### DIFF
--- a/templates/default/docker-storage.erb
+++ b/templates/default/docker-storage.erb
@@ -35,3 +35,10 @@ VG="<%= node['cookbook-openshift3']['openshift_node_docker-storage']['VG'] %>"
 DATA_SIZE="<%= node['cookbook-openshift3']['openshift_node_docker-storage']['DATA_SIZE'] %>"
 <% end -%>
 WIPE_SIGNATURES="true"
+<%
+  node['cookbook-openshift3']['openshift_node_docker-storage'].reject do |key|
+    %w[DEVS VG DATA_SIZE WIPE_SIGNATURES].include?(key)
+  end.sort.each do |key, value|
+-%>
+<%= key %>="<%= Shellwords.escape(value) %>"
+<% end -%>


### PR DESCRIPTION
This PR allows to declare arbitrary environment variables inside the `node['cookbook-openshift3']['openshift_node_docker-storage']`, which will be rendered in `/etc/sysconfig/docker-storage-setup`.

Objective : to configure any options listed in https://github.com/projectatomic/container-storage-setup/blob/master/container-storage-setup.conf ; for example, automatic extension of the docker LVM thin pool could b e be done by setting:
```
default['cookbook-openshift3']['openshift_node_docker-storage'] = {
  "VG": "vg",
  "DATA_SIZE": "50G",
  "AUTO_EXTEND_POOL": false
}
```