### PR TITLE
Filter out tuned-profiles-origin-node for OSE v3.9 -- it does not exist on repository

### DIFF
--- a/resources/openshift_master_pkg.rb
+++ b/resources/openshift_master_pkg.rb
@@ -58,7 +58,7 @@ action :install do
   end
 
   if node['cookbook-openshift3']['ose_major_version'].split('.')[1].to_i < 10
-    yum_package pkg_master_to_install.reject { |x| x == "tuned-profiles-#{node['cookbook-openshift3']['openshift_service_type']}-node" && node['cookbook-openshift3']['control_upgrade_version'].to_i >= 39 } do
+    yum_package pkg_master_to_install.reject { |x| x == "tuned-profiles-#{node['cookbook-openshift3']['openshift_service_type']}-node" && (node['cookbook-openshift3']['ose_major_version'].split('.')[1].to_i >= 9 || node['cookbook-openshift3']['control_upgrade_version'].to_i >= 39) } do
       action :install
       version Array.new(pkg_master_to_install.size, version) unless version.nil?
       options new_resource.options.nil? ? node['cookbook-openshift3']['openshift_yum_options'] : new_resource.options


### PR DESCRIPTION
When installing OSE v3.9.0 using the latest released version of this cookbook (v2.1.2), the converge fails because the cookbook tries to install v3.9.0 of package `tuned-profiles-origin-node` which does not exist on https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin39/

Note: for earlier OSE versions (from 3.6 to 3.8) the package exists on the repositories.

This PR filters out the `tuned-profiles-origin-node` from the list of packages to install on the server when the current ose_major_version is 3.9.

Full chef stack trace before the PR:
```
         * iptables_rule[firewall_certificate] action enable
           * template[/etc/iptables.d/firewall_certificate] action create
             - create new file /etc/iptables.d/firewall_certificate
             - update content in file /etc/iptables.d/firewall_certificate from none to 58bfcf
             --- /etc/iptables.d/firewall_certificate	2018-12-19 13:16:09.613963052 +0000
             +++ /etc/iptables.d/.chef-firewall_certificate20181219-16012-5vaw84	2018-12-19 13:16:09.613963052 +0000
             @@ -1 +1,2 @@
             +-A OS_FIREWALL_ALLOW -m state --state NEW,ESTABLISHED -m comment --comment "OpenShift HTTPD" -m tcp -p tcp --dport 9999 -j ACCEPT
             - change mode from '' to '0644'
             - restore selinux security context
         
         * cookbook_openshift3_openshift_master_pkg[Install OpenShift Master Packages for Certificate Server] action install
           * yum_package[origin-master, origin-clients, origin, origin-node, tuned-profiles-origin-node, origin-sdn-ovs] action install
             * No candidate version available for tuned-profiles-origin-node
             * No candidate version available for tuned-profiles-origin-node
             * No candidate version available for tuned-profiles-origin-node
             * No candidate version available for tuned-profiles-origin-node
             ================================================================================
             Error executing action `install` on resource 'yum_package[origin-master, origin-clients, origin, origin-node, tuned-profiles-origin-node, origin-sdn-ovs]'
             ================================================================================
             
             Chef::Exceptions::Package
             -------------------------
             No candidate version available for tuned-profiles-origin-node
             
             Resource Declaration:
             ---------------------
             # In /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/resources/openshift_master_pkg.rb
             
       61:     yum_package pkg_master_to_install.reject { |x| x == "tuned-profiles-#{node['cookbook-openshift3']['openshift_service_type']}-node" && node['cookbook-openshift3']['control_upgrade_version'].to_i >= 39 } do
       62:       action :install
       63:       version Array.new(pkg_master_to_install.size, version) unless version.nil?
       64:       options new_resource.options.nil? ? node['cookbook-openshift3']['openshift_yum_options'] : new_resource.options
       65:       notifies :run, 'execute[daemon-reload]', :immediately
       66:       not_if { node['cookbook-openshift3']['deploy_containerized'] || (is_certificate_server && node['fqdn'] != first_master['fqdn']) }
       67:       retries 3
       68:     end
       69: 
             
             Compiled Resource:
             ------------------
             # Declared in /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/resources/openshift_master_pkg.rb:61:in `block in class_from_file'
             
             yum_package("origin-master, origin-clients, origin, origin-node, tuned-profiles-origin-node, origin-sdn-ovs") do
        package_name ["origin-master", "origin-clients", "origin", "origin-node", "tuned-profiles-origin-node", "origin-sdn-ovs"]
        action [:install]
        default_guard_interpreter :default
        declared_type :yum_package
        cookbook_name "cookbook-openshift3"
        version ["3.9.0-1.el7.git.0.ba7faec", "3.9.0-1.el7.git.0.ba7faec", "3.9.0-1.el7.git.0.ba7faec", "3.9.0-1.el7.git.0.ba7faec", "3.9.0-1.el7.git.0.ba7faec", "3.9.0-1.el7.git.0.ba7faec"]
        retries 3
        options []
        not_if { #code block }
             end
             
             System Info:
             ------------
             chef_version=14.8.12
             platform=centos
             platform_version=7.4.1708
             ruby=ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
             program_name=/opt/chef/bin/chef-client
             executable=/opt/chef/bin/chef-client
             
           
           ================================================================================
           Error executing action `install` on resource 'cookbook_openshift3_openshift_master_pkg[Install OpenShift Master Packages for Certificate Server]'
           ================================================================================
           
           Chef::Exceptions::Package
           -------------------------
           yum_package[origin-master, origin-clients, origin, origin-node, tuned-profiles-origin-node, origin-sdn-ovs] (/tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/resources/openshift_master_pkg.rb line 61) had an error: Chef::Exceptions::Package: No candidate version available for tuned-profiles-origin-node
           
           Resource Declaration:
           ---------------------
           # In /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/certificate_server.rb
           
            20:   openshift_master_pkg 'Install OpenShift Master Packages for Certificate Server'
            21: 
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/recipes/certificate_server.rb:20:in `from_file'
           
           cookbook_openshift3_openshift_master_pkg("Install OpenShift Master Packages for Certificate Server") do
             action [:install]
             default_guard_interpreter :default
             declared_type :openshift_master_pkg
             cookbook_name "cookbook-openshift3"
             recipe_name "certificate_server"
           end
           
           System Info:
           ------------
           chef_version=14.8.12
           platform=centos
           platform_version=7.4.1708
           ruby=ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
           program_name=/opt/chef/bin/chef-client
           executable=/opt/chef/bin/chef-client
           
       Recipe: iptables::default
         * execute[rebuild-iptables] action run
           - execute /usr/sbin/rebuild-iptables
       
       Running handlers:
       [2018-12-19T13:16:16+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2018-12-19T13:16:16+00:00] ERROR: Exception handlers complete
       Chef Client failed. 35 resources updated in 01 minutes 58 seconds
       [2018-12-19T13:16:16+00:00] FATAL: Stacktrace dumped to /tmp/vagrant-cache/chef/chef-stacktrace.out
       [2018-12-19T13:16:16+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2018-12-19T13:16:16+00:00] FATAL: Chef::Exceptions::Package: cookbook_openshift3_openshift_master_pkg[Install OpenShift Master Packages for Certificate Server] (cookbook-openshift3::certificate_server line 20) had an error: Chef::Exceptions::Package: yum_package[origin-master, origin-clients, origin, origin-node, tuned-profiles-origin-node, origin-sdn-ovs] (/tmp/vagrant-cache/chef/cookbooks/cookbook-openshift3/resources/openshift_master_pkg.rb line 61) had an error: Chef::Exceptions::Package: No candidate version available for tuned-profiles-origin-node
```