### PR TITLE
Pool openshift_master_loopback_api_url (localhost) without http proxy

### DIFF
--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -221,6 +221,7 @@ end
 
 execute 'Wait for API to become available' do
   command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+  environment 'no_proxy' => 'localhost'
   retries 120
   retry_delay 1
 end

--- a/recipes/master_config_post.rb
+++ b/recipes/master_config_post.rb
@@ -13,6 +13,7 @@ service_accounts = node['cookbook-openshift3']['openshift_common_service_account
 
 execute 'Check Master API' do
   command "[[ $(curl --silent #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+  environment 'no_proxy' => 'localhost'
   retries 120
   retry_delay 1
 end

--- a/recipes/ng_nodes_certificates.rb
+++ b/recipes/ng_nodes_certificates.rb
@@ -25,6 +25,7 @@ end
 
 execute 'Wait for API to become available' do
   command is_master_server ? "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['master_certs_generated_certs_dir']}/ca-bundle.crt) =~ \"ok\" ]]" : "[[ $(curl --silent --tlsv1.2 --max-time 2 -k #{node['cookbook-openshift3']['openshift_master_api_url']}/healthz/ready) =~ \"ok\" ]]"
+  environment 'no_proxy' => 'localhost'
   retries 150
   retry_delay 5
 end

--- a/recipes/upgrade_control_plane38_part1.rb
+++ b/recipes/upgrade_control_plane38_part1.rb
@@ -74,6 +74,7 @@ if is_master_server && is_first_master
 
   execute 'Wait for API to be ready (3.8)' do
     command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+    environment 'no_proxy' => 'localhost'
     retries 120
     retry_delay 1
   end

--- a/recipes/upgrade_control_plane39_part1.rb
+++ b/recipes/upgrade_control_plane39_part1.rb
@@ -74,6 +74,7 @@ if is_master_server && is_first_master
 
   execute 'Wait for API to be ready (3.9)' do
     command "[[ $(curl --silent --tlsv1.2 --max-time 2 #{node['cookbook-openshift3']['openshift_master_loopback_api_url']}/healthz/ready --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca.crt --cacert #{node['cookbook-openshift3']['openshift_master_config_dir']}/ca-bundle.crt) =~ \"ok\" ]]"
+    environment 'no_proxy' => 'localhost'
     retries 120
     retry_delay 1
   end


### PR DESCRIPTION
This PR forces `environment 'no_proxy' => 'localhost'` for every curl command which polls the openshift master on the loopback url (localhost).

## The problem

I have a server which has the following environment:
```sh
[root@staging ~]# env | grep proxy
http_proxy=http://192.168.122.1:3128
ftp_proxy=
https_proxy=http://192.168.122.1:3128
no_proxy=192.168.122.1,.staging.example.com
```

Running `chef-client` on this server fails to converge because the `execute[Wait for API to become available]` resources which poll the openshift API server at localhost try to pass through the system http proxy (which has a different localhost than the host running the origin master service).

## Symptom

```sh
Recipe: cookbook-openshift3::master_cluster
  * execute[Wait for master api service to start on first master] action run (skipped due to not_if)
  * execute[Activate services for Master API on all masters] action run (skipped due to only_if)
  * execute[Wait for API to become available] action run^C[2019-01-03T14:32:57+00:00] FATAL: SIGINT received, stopping <---- gives up after 2 minutes but I didn't have the patience.
```