### PR TITLE
#136 - restart iptables

### DIFF
--- a/recipes/certificate_server.rb
+++ b/recipes/certificate_server.rb
@@ -14,6 +14,7 @@ if is_certificate_server
   node['cookbook-openshift3']['enabled_firewall_rules_certificate'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -34,6 +34,7 @@ if !lb_servers.nil? && lb_servers.find { |lb| lb['fqdn'] == node['fqdn'] }
   node['cookbook-openshift3']['enabled_firewall_rules_lb'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -39,6 +39,7 @@ if is_etcd_server || is_new_etcd_server
   node['cookbook-openshift3']['enabled_firewall_rules_etcd'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -22,6 +22,7 @@ if is_master_server
   node['cookbook-openshift3']['enabled_firewall_rules_master'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -16,6 +16,7 @@ ose_major_version = node['cookbook-openshift3']['deploy_containerized'] == true 
 node['cookbook-openshift3']['enabled_firewall_rules_master_cluster'].each do |rule|
   iptables_rule rule do
     action :enable
+     notifies :restart, 'service[iptables]', :immediately
   end
 end
 

--- a/recipes/ng_certificate_server.rb
+++ b/recipes/ng_certificate_server.rb
@@ -7,6 +7,7 @@
 node['cookbook-openshift3']['enabled_firewall_rules_certificate'].each do |rule|
   iptables_rule rule do
     action :enable
+    notifies :restart, 'service[iptables]', :immediately
   end
 end
 

--- a/recipes/ng_etcd_cluster.rb
+++ b/recipes/ng_etcd_cluster.rb
@@ -30,6 +30,7 @@ if is_etcd_server || is_new_etcd_server
   node['cookbook-openshift3']['enabled_firewall_rules_etcd'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/ng_master.rb
+++ b/recipes/ng_master.rb
@@ -16,6 +16,7 @@ if is_master_server
   node['cookbook-openshift3']['enabled_firewall_rules_master_cluster'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 

--- a/recipes/ng_node.rb
+++ b/recipes/ng_node.rb
@@ -25,6 +25,7 @@ end
 node['cookbook-openshift3']['enabled_firewall_rules_node'].each do |rule|
   iptables_rule rule do
     action :enable
+    notifies :restart, 'service[iptables]', :immediately
   end
 end
 

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -39,6 +39,7 @@ if is_node_server
   node['cookbook-openshift3']['enabled_firewall_rules_node'].each do |rule|
     iptables_rule rule do
       action :enable
+      notifies :restart, 'service[iptables]', :immediately
     end
   end
 


### PR DESCRIPTION
It seems that a restart to iptables is now required to get the iptables rules adopted. If it is restarted later in the script, a race condition emerges where etcd can't start because the other nodes depended on can't download the certificates from the cert server.

This change restarts iptables in all the places where iptables rules are set.

Just testing by hand now.