### PR TITLE
Allow to specify fqdn whitelist in `node['cookbook-openshift3']['openshift_logging_fluentd_hosts']`.

### DIFF
--- a/providers/openshift_deploy_logging.rb
+++ b/providers/openshift_deploy_logging.rb
@@ -568,11 +568,15 @@ action :create do
     end
 
     # Retrieve the list of Fluentd nodes
-    whitelisted_fluentd_hosts = Array(node['cookbook-openshift3']['openshift_logging_fluentd_hosts'])
+    whitelisted_fluentd_hosts = Array(node['cookbook-openshift3']['openshift_logging_fluentd_hosts']).dup
     if whitelisted_fluentd_hosts == %w[--all]
       whitelisted_fluentd_hosts = OpenShiftHelper::NodeHelper.new(node).node_servers.map do |server_node|
         server_node['fqdn']
       end
+    else
+      # due to how chef merges Array attributes, the `--all` value may still be present in #{whitelisted_fluentd_hosts};
+      # this may happen especially on the first run after setting openshift_logging_fluentd_hosts to non-default value.
+      whitelisted_fluentd_hosts.delete('--all')
     end
 
     # Set Fluentd labels on whitelisted nodes

--- a/providers/openshift_deploy_logging.rb
+++ b/providers/openshift_deploy_logging.rb
@@ -567,13 +567,36 @@ action :create do
       end
     end
 
-    execute 'Set Fluentd Labels for all nodes' do
-      command "#{node['cookbook-openshift3']['openshift_common_client_binary']} label node --all ${key}=${value} --overwrite --config=#{FOLDER}/admin.kubeconfig"
+    # Retrieve the list of Fluentd nodes
+    whitelisted_fluentd_hosts = Array(node['cookbook-openshift3']['openshift_logging_fluentd_hosts'])
+    if whitelisted_fluentd_hosts == %w[--all]
+      whitelisted_fluentd_hosts = OpenShiftHelper::NodeHelper.new(node).node_servers.map do |server_node|
+        server_node['fqdn']
+      end
+    end
+
+    # Set Fluentd labels on whitelisted nodes
+    whitelisted_fluentd_hosts.each do |fqdn|
+      execute "Set Fluentd Labels on whitelisted node #{fqdn}" do
+        command "#{node['cookbook-openshift3']['openshift_common_client_binary']} label node ${node} ${key}=${value} --overwrite --config=#{FOLDER}/admin.kubeconfig"
+        environment(
+          'node' => fqdn,
+          'key' => node['cookbook-openshift3']['openshift_logging_fluentd_nodeselector'].keys.first.to_s,
+          'value' => node['cookbook-openshift3']['openshift_logging_fluentd_nodeselector'].values.first.to_s
+        )
+        not_if "[[ $(#{node['cookbook-openshift3']['openshift_common_client_binary']} get node -l kubernetes.io/hostname=${node},${key}=${value} --no-headers --config=#{FOLDER}/admin.kubeconfig | wc -l) > 0 ]]"
+        only_if "[[ $(#{node['cookbook-openshift3']['openshift_common_client_binary']} get node -l kubernetes.io/hostname=${node} --no-headers --config=#{FOLDER}/admin.kubeconfig | wc -l) > 0 ]]"
+      end
+    end
+
+    # Remove existing Fluentd labels on non-whitelisted nodes
+    execute 'Remove Fluentd labels from non-whitelisted nodes' do
+      command "#{node['cookbook-openshift3']['openshift_common_client_binary']} label node -l ${key}${selector} ${key}- --overwrite --config=#{FOLDER}/admin.kubeconfig"
       environment(
-        'key' => node['cookbook-openshift3']['openshift_logging_fluentd_nodeselector'].keys.first.to_s,
-        'value' => node['cookbook-openshift3']['openshift_logging_fluentd_nodeselector'].values.first.to_s
+        'selector' => whitelisted_fluentd_hosts.map { |fqdn| ",kubernetes.io/hostname!=#{fqdn}" }.join(''),
+        'key' => node['cookbook-openshift3']['openshift_logging_fluentd_nodeselector'].keys.first.to_s
       )
-      only_if "[[ $(#{node['cookbook-openshift3']['openshift_common_client_binary']} get node -l ${key}!=${value} --no-headers --config=#{FOLDER}/admin.kubeconfig | wc -l) > 0 ]]"
+      only_if "[[ $(#{node['cookbook-openshift3']['openshift_common_client_binary']} get node -l ${key}${selector} --no-headers --config=#{FOLDER}/admin.kubeconfig | wc -l) > 0 ]]"
     end
   end
 end


### PR DESCRIPTION
This PR implements support for specifying a whitelist of hosts where the fluentd damonset should run.

Possible values for ` node['cookbook-openshift3']['openshift_logging_fluentd_hosts']`:
 - `['--all']` (default, compatible with current behavior): run fluentd on every node
 - `{}`, `[]` or `nil`: run fluentd on no node
 - `['host1', 'host2']`: run fluentd only on nodes named `host1` or `host2`

I took inspiration from:
 - [OSE v3.9 aggregate logging](https://docs.openshift.com/container-platform/3.9/install_config/aggregate_logging.html) for documentation
 - [openshift-ansible](https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_logging_fluentd/tasks/main.yaml#L204-L227) for implementation