### PR TITLE
Add missing CheckVolumeBinding predicate (fix Local Persistent Volumes for OSE 3.9)

### DIFF
--- a/templates/default/scheduler.json.erb
+++ b/templates/default/scheduler.json.erb
@@ -67,6 +67,7 @@
         {"name": "PodToleratesNodeTaints"},
         {"name": "CheckNodeMemoryPressure"},
         {"name": "CheckNodeDiskPressure"},
+        {"name": "CheckVolumeBinding"},
 <%- end -%>
         {
             "argument": {


### PR DESCRIPTION
I noticed that Local Persistent Volumes are broken when using OSE v3.9 and the current version of this cookbook.

In the origin-node log for one of the nodes which should receive a pod that uses a local persistent volume, the following messages can be seen :

```
Apr 01 16:08:52 backends-3 origin-node[24918]: E0401 16:08:52.113264   24918 reconciler.go:258] operationExecutor.MountVolume failed (controllerAttachDetachEnabled true) for volume "volume-mongodb-backends" (UniqueName: "kubernetes.io/local-volume/dfe58996-5492-11e9-b92c-0800278bc93f-volume-mongodb-backends") pod "mongodb-0" (UID: "dfe58996-5492-11e9-b92c-0800278bc93f") : MountVolume.NodeAffinity check failed for volume "volume-mongodb-backends" (UniqueName: "kubernetes.io/local-volume/dfe58996-5492-11e9-b92c-0800278bc93f-volume-mongodb-backends") pod "mongodb-0" (UID: "dfe58996-5492-11e9-b92c-0800278bc93f") : NodeSelectorTerm [{Key:kubernetes.io/hostname Operator:In Values:[backends]}] does not match node labels
```

Apparently, the node configuration is missing the `CheckVolumeBinding` scheduler predicate when using OSE v3.9.

Compare:
 - openshift-ansible : https://github.com/openshift/openshift-ansible/blob/release-3.10/roles/lib_utils/lookup_plugins/openshift_master_facts_default_predicates.py#L67-L80
 - this cookbook: https://github.com/IshentRas/cookbook-openshift3/blob/master/templates/default/scheduler.json.erb#L59-L69