### PR TITLE
Consistently downcase the masterKubeConfig path

### DIFF
--- a/templates/default/node.yaml.erb
+++ b/templates/default/node.yaml.erb
@@ -56,7 +56,7 @@ masterClientConnectionOverrides:
 <% if node['cookbook-openshift3']['use_wildcard_nodes'] %>
 masterKubeConfig: system:node:wildcard_nodes.kubeconfig
 <%- else -%>
-masterKubeConfig: system:node:<%= node['fqdn'] %>.kubeconfig
+masterKubeConfig: system:node:<%= node['fqdn'].downcase %>.kubeconfig
 <%- end -%>
 networkPluginName: <%= node['cookbook-openshift3']['openshift_common_sdn_network_plugin_name'] %>
 # networkConfig struct introduced in origin 1.0.6 and OSE 3.0.2 which


### PR DESCRIPTION
This PR is a short fix for a bug I encountered when trying to provision a node whose fqdn contains uppercase letters (eg.`MY-OSE-SERVER.example.com`).

## The symptoms

The chef run failed with a broken origin-node service.
The interesting snippet was in the origin-node service logs :
```
May 21 12:19:15 MY-OSE-SERVER origin-node[32335]: I0521 12:19:15.969796   32335 start_node.go:309] Reading node configuration from /etc/origin/node/node-config.yaml
May 21 12:19:15 MY-OSE-SERVER origin-node[32335]: Invalid NodeConfig /etc/origin/node/node-config.yaml
May 21 12:19:15 MY-OSE-SERVER origin-node[32335]: masterKubeConfig: Invalid value: "/etc/origin/node/system:node:MY-OSE-SERVER.example.com.kubeconfig": could not read file: stat /etc/origin/node/system:node:MY-OSE-SERVER.example.com.kubeconfig: no such file or directory
May 21 12:19:15 MY-OSE-SERVER systemd[1]: origin-node.service: main process exited, code=exited, status=255/n/a
```

## The investigation

Apparently, the cookbook downcases the path of the master kube config path when it creates it on the disk, but it does not downcase the path when referencing that file in /etc/origin/node/node-config.yaml.

## The fix

The fix is just to downcase the masterKubeConfig entry in the template that is rendered into /etc/origin/node/node-config.yaml

Before this PR:
```
$ grep --color -ry system:node.*fqdn.*kubeconfig *
templates/default/openshift_node/node.yaml.v1.erb:masterKubeConfig: system:node:<%= node['fqdn'].downcase %>.kubeconfig
templates/default/node.yaml.erb:masterKubeConfig: system:node:<%= node['fqdn'] %>.kubeconfig
```

After this PR:
```
$ grep --color -ry system:node.*fqdn.*kubeconfig *
templates/default/openshift_node/node.yaml.v1.erb:masterKubeConfig: system:node:<%= node['fqdn'].downcase %>.kubeconfig
templates/default/node.yaml.erb:masterKubeConfig: system:node:<%= node['fqdn'].downcase %>.kubeconfig
```