### PR TITLE
Certserver hardening

### DIFF
--- a/libraries/openshift_helper.rb
+++ b/libraries/openshift_helper.rb
@@ -174,6 +174,10 @@ module OpenShiftHelper
       ca_exist && !dir_exist
     end
 
+    def certificate_server_protocol
+      node['cookbook-openshift3']['httpd_secure'] ? 'https' : 'http'
+    end
+
     def get_nodevar(var)
       if node_servers.any? { |server_node| server_node['fqdn'] == node['fqdn'] && server_node.key?(var) }
         node_servers.find { |server_node| server_node['fqdn'] == node['fqdn'] }[var.to_s]

--- a/recipes/adhoc_migrate_etcd.rb
+++ b/recipes/adhoc_migrate_etcd.rb
@@ -14,6 +14,7 @@ certificate_server = server_info.certificate_server
 is_certificate_server = server_info.on_certificate_server?
 is_control_plane_server = server_info.on_control_plane_server?
 etcd_servers = server_info.etcd_servers
+certificate_server_protocol = server_info.certificate_server_protocol
 
 include_recipe 'cookbook-openshift3::services'
 
@@ -178,7 +179,7 @@ unless etcd_servers.size == 1
 
     remote_file "Retrieve ETCD SystemD Drop-in from Certificate Server[#{certificate_server['fqdn']}]" do
       path "/etc/systemd/system/#{node['cookbook-openshift3']['etcd_service_name']}.service.d/etcd-dropin"
-      source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/migration/etcd-#{node['fqdn']}"
+      source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/migration/etcd-#{node['fqdn']}"
       notifies :run, 'execute[daemon-reload]', :immediately
       retries 120
       retry_delay 5

--- a/recipes/adhoc_migrate_etcd.rb
+++ b/recipes/adhoc_migrate_etcd.rb
@@ -180,6 +180,7 @@ unless etcd_servers.size == 1
     remote_file "Retrieve ETCD SystemD Drop-in from Certificate Server[#{certificate_server['fqdn']}]" do
       path "/etc/systemd/system/#{node['cookbook-openshift3']['etcd_service_name']}.service.d/etcd-dropin"
       source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/migration/etcd-#{node['fqdn']}"
+      headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
       notifies :run, 'execute[daemon-reload]', :immediately
       retries 120
       retry_delay 5

--- a/recipes/etcd_certificates.rb
+++ b/recipes/etcd_certificates.rb
@@ -6,6 +6,7 @@
 
 server_info = OpenShiftHelper::NodeHelper.new(node)
 etcd_servers = server_info.etcd_servers + server_info.new_etcd_servers
+master_servers = server_info.master_servers
 is_certificate_server = server_info.on_certificate_server?
 
 if node['cookbook-openshift3']['encrypted_file_password']['data_bag_name'] && node['cookbook-openshift3']['encrypted_file_password']['data_bag_item_name']
@@ -79,6 +80,14 @@ if is_certificate_server
     source 'access-htaccess.erb'
     notifies :run, 'ruby_block[Modify the AllowOverride options]', :immediately
     variables(servers: etcd_servers)
+  end
+
+  template "#{node['cookbook-openshift3']['etcd_generated_ca_dir']}/.htaccess" do
+    owner 'apache'
+    group 'apache'
+    source 'access-htaccess.erb'
+    notifies :run, 'ruby_block[Modify the AllowOverride options]', :immediately
+    variables(servers: etcd_servers + master_servers)
   end
 
   remote_file '/var/www/html/etcd/ca.crt' do

--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -14,6 +14,7 @@ is_etcd_server = server_info.on_etcd_server?
 is_new_etcd_server = server_info.on_new_etcd_server?
 is_master_server = server_info.on_master_server?
 etcd_healthy = helper.checketcd_healthy?
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if node['cookbook-openshift3']['encrypted_file_password']['data_bag_name'] && node['cookbook-openshift3']['encrypted_file_password']['data_bag_item_name']
   secret_file = node['cookbook-openshift3']['encrypted_file_password']['secret_file'] || nil
@@ -73,7 +74,7 @@ if is_etcd_server || is_new_etcd_server
   end
 
   remote_file "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt" do
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
     retries ::Mixlib::ShellOut.new("systemctl is-enabled #{node['cookbook-openshift3']['etcd_service_name']}").run_command.error? ? 180 : 60
     retry_delay 5
     sensitive true
@@ -82,7 +83,7 @@ if is_etcd_server || is_new_etcd_server
 
   remote_file "Retrieve ETCD certificates from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['etcd_conf_dir']}/etcd-#{node['fqdn']}.tgz.enc"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/generated_certs/etcd-#{node['fqdn']}.tgz.enc"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/generated_certs/etcd-#{node['fqdn']}.tgz.enc"
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt etcd certificate tgz files]', :immediately
     notifies :run, 'execute[Extract certificate to ETCD folder]', :immediately

--- a/recipes/etcd_cluster.rb
+++ b/recipes/etcd_cluster.rb
@@ -76,6 +76,7 @@ if is_etcd_server || is_new_etcd_server
   remote_file "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt" do
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
     retries ::Mixlib::ShellOut.new("systemctl is-enabled #{node['cookbook-openshift3']['etcd_service_name']}").run_command.error? ? 180 : 60
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     retry_delay 5
     sensitive true
     action :create_if_missing
@@ -87,6 +88,7 @@ if is_etcd_server || is_new_etcd_server
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt etcd certificate tgz files]', :immediately
     notifies :run, 'execute[Extract certificate to ETCD folder]', :immediately
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     retries 60
     retry_delay 5
   end

--- a/recipes/etcd_recovery.rb
+++ b/recipes/etcd_recovery.rb
@@ -91,6 +91,7 @@ if is_etcd_server && ::File.file?(node['cookbook-openshift3']['adhoc_recovery_et
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/recovery/etcd-#{node['fqdn']}"
     notifies :run, 'execute[daemon-reload]', :immediately
     notifies :delete, "directory[#{node['cookbook-openshift3']['etcd_data_dir']}/member]", :immediately
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     retries 120
     retry_delay 5
   end

--- a/recipes/etcd_recovery.rb
+++ b/recipes/etcd_recovery.rb
@@ -11,6 +11,7 @@ certificate_server = server_info.certificate_server
 is_certificate_server = server_info.on_certificate_server?
 etcd_servers = server_info.etcd_servers
 etcd_healthy = helper.checketcd_healthy?
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if is_certificate_server && etcd_healthy && ::File.file?(node['cookbook-openshift3']['adhoc_recovery_etcd_certificate_server'])
   file node['cookbook-openshift3']['adhoc_recovery_etcd_certificate_server'] do
@@ -87,7 +88,7 @@ if is_etcd_server && ::File.file?(node['cookbook-openshift3']['adhoc_recovery_et
 
   remote_file "Retrieve ETCD SystemD Drop-in from Certificate Server[#{certificate_server['fqdn']}]" do
     path "/etc/systemd/system/#{node['cookbook-openshift3']['etcd_service_name']}.service.d/etcd-dropin"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/recovery/etcd-#{node['fqdn']}"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/recovery/etcd-#{node['fqdn']}"
     notifies :run, 'execute[daemon-reload]', :immediately
     notifies :delete, "directory[#{node['cookbook-openshift3']['etcd_data_dir']}/member]", :immediately
     retries 120

--- a/recipes/etcd_scaleup.rb
+++ b/recipes/etcd_scaleup.rb
@@ -13,6 +13,7 @@ is_new_etcd_server = server_info.on_new_etcd_server?
 is_certificate_server = server_info.on_certificate_server?
 etcds = etcd_servers.map { |srv| "https://#{srv['ipaddress']}:2379" }.join(',')
 path_bin = node['cookbook-openshift3']['openshift_docker_etcd_image'].include?('coreos') ? '/usr/local/bin/etcd' : '/usr/bin/etcd'
+certificate_server_protocol = server_info.certificate_server_protocol
 
 unless new_etcd_servers.empty?
   if is_certificate_server
@@ -60,7 +61,7 @@ unless new_etcd_servers.empty?
 
       remote_file "Retrieve ETCD SystemD Drop-in from Certificate Server[#{certificate_server['fqdn']}]" do
         path "/etc/systemd/system/#{node['cookbook-openshift3']['etcd_service_name']}.service.d/etcd-dropin"
-        source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/scaleup/etcd-#{node['fqdn']}"
+        source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/scaleup/etcd-#{node['fqdn']}"
         action :create_if_missing
         notifies :run, 'execute[daemon-reload]', :immediately
         notifies :start, 'service[etcd-service]', :immediately

--- a/recipes/etcd_scaleup.rb
+++ b/recipes/etcd_scaleup.rb
@@ -62,6 +62,7 @@ unless new_etcd_servers.empty?
       remote_file "Retrieve ETCD SystemD Drop-in from Certificate Server[#{certificate_server['fqdn']}]" do
         path "/etc/systemd/system/#{node['cookbook-openshift3']['etcd_service_name']}.service.d/etcd-dropin"
         source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/scaleup/etcd-#{node['fqdn']}"
+        headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
         action :create_if_missing
         notifies :run, 'execute[daemon-reload]', :immediately
         notifies :start, 'service[etcd-service]', :immediately

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -10,6 +10,7 @@ first_master = server_info.first_master
 master_servers = server_info.master_servers
 etcd_servers = server_info.etcd_servers
 certificate_server = server_info.certificate_server
+certificate_server_protocol = server_info.certificate_server_protocol
 
 ose_major_version = node['cookbook-openshift3']['deploy_containerized'] == true ? node['cookbook-openshift3']['openshift_docker_image_version'] : node['cookbook-openshift3']['ose_major_version']
 
@@ -60,7 +61,7 @@ end
 
 remote_file "Retrieve ETCD client certificate from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-master-#{node['fqdn']}.tgz.enc"
-  source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
+  source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt etcd certificates tgz files]', :immediately
   notifies :run, 'execute[Extract etcd certificates to Master folder]', :immediately
@@ -83,7 +84,7 @@ end
 
 remote_file "Retrieve ETCD CA cert from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt"
-  source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+  source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
   owner 'root'
   group 'root'
   mode '0600'
@@ -95,7 +96,7 @@ end
 
 remote_file "Retrieve master certificates from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-#{node['fqdn']}.tgz.enc"
-  source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
+  source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt master certificates master tgz files]', :immediately
   notifies :run, 'execute[Extract master certificates to Master folder]', :immediately

--- a/recipes/master_cluster.rb
+++ b/recipes/master_cluster.rb
@@ -62,6 +62,7 @@ end
 remote_file "Retrieve ETCD client certificate from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-master-#{node['fqdn']}.tgz.enc"
   source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
+  headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt etcd certificates tgz files]', :immediately
   notifies :run, 'execute[Extract etcd certificates to Master folder]', :immediately
@@ -85,6 +86,7 @@ end
 remote_file "Retrieve ETCD CA cert from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt"
   source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+  headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
   owner 'root'
   group 'root'
   mode '0600'
@@ -97,6 +99,7 @@ end
 remote_file "Retrieve master certificates from Certificate Server[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-#{node['fqdn']}.tgz.enc"
   source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
+  headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt master certificates master tgz files]', :immediately
   notifies :run, 'execute[Extract master certificates to Master folder]', :immediately

--- a/recipes/ng_etcd_cluster.rb
+++ b/recipes/ng_etcd_cluster.rb
@@ -70,6 +70,7 @@ if is_etcd_server || is_new_etcd_server
 
   remote_file "#{node['cookbook-openshift3']['etcd_conf_dir']}/ca.crt" do
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     retries 60
     retry_delay 5
     sensitive true
@@ -79,6 +80,7 @@ if is_etcd_server || is_new_etcd_server
   remote_file "Retrieve ETCD certificates from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['etcd_conf_dir']}/etcd-#{node['fqdn']}.tgz.enc"
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/generated_certs/etcd-#{node['fqdn']}.tgz.enc"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt etcd certificate tgz files]', :immediately
     notifies :run, 'execute[Extract certificate to ETCD folder]', :immediately

--- a/recipes/ng_master.rb
+++ b/recipes/ng_master.rb
@@ -11,6 +11,7 @@ is_first_master = server_info.on_first_master?
 is_certificate_server = server_info.on_certificate_server?
 docker_version = node['cookbook-openshift3']['openshift_docker_image_version']
 service_accounts = node['cookbook-openshift3']['openshift_common_service_accounts_additional'].any? ? node['cookbook-openshift3']['openshift_common_service_accounts'] + node['cookbook-openshift3']['openshift_common_service_accounts_additional'] : node['cookbook-openshift3']['openshift_common_service_accounts']
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if is_master_server
   node['cookbook-openshift3']['enabled_firewall_rules_master_cluster'].each do |rule|
@@ -49,7 +50,7 @@ if is_master_server
 
   remote_file "Retrieve ETCD client certificate from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-master-#{node['fqdn']}.tgz.enc"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt etcd certificates tgz files]', :immediately
     notifies :run, 'execute[Extract etcd certificates to Master folder]', :immediately
@@ -72,7 +73,7 @@ if is_master_server
 
   remote_file "Retrieve ETCD CA cert from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
     owner 'root'
     group 'root'
     mode '0600'
@@ -84,7 +85,7 @@ if is_master_server
 
   remote_file "Retrieve master certificates from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-#{node['fqdn']}.tgz.enc"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt master certificates master tgz files]', :immediately
     notifies :run, 'execute[Extract master certificates to Master folder]', :immediately

--- a/recipes/ng_master.rb
+++ b/recipes/ng_master.rb
@@ -51,6 +51,7 @@ if is_master_server
   remote_file "Retrieve ETCD client certificate from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-master-#{node['fqdn']}.tgz.enc"
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-master-#{node['fqdn']}.tgz.enc"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt etcd certificates tgz files]', :immediately
     notifies :run, 'execute[Extract etcd certificates to Master folder]', :immediately
@@ -74,6 +75,7 @@ if is_master_server
   remote_file "Retrieve ETCD CA cert from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/#{node['cookbook-openshift3']['master_etcd_cert_prefix']}ca.crt"
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/etcd/ca.crt"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     owner 'root'
     group 'root'
     mode '0600'
@@ -86,6 +88,7 @@ if is_master_server
   remote_file "Retrieve master certificates from Certificate Server[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/openshift-#{node['fqdn']}.tgz.enc"
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/openshift-#{node['fqdn']}.tgz.enc"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt master certificates master tgz files]', :immediately
     notifies :run, 'execute[Extract master certificates to Master folder]', :immediately

--- a/recipes/ng_node_join.rb
+++ b/recipes/ng_node_join.rb
@@ -6,6 +6,7 @@
 
 server_info = OpenShiftHelper::NodeHelper.new(node)
 certificate_server = server_info.certificate_server
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if node['cookbook-openshift3']['encrypted_file_password']['data_bag_name'] && node['cookbook-openshift3']['encrypted_file_password']['data_bag_item_name']
   secret_file = node['cookbook-openshift3']['encrypted_file_password']['secret_file'] || nil
@@ -16,7 +17,7 @@ end
 
 remote_file "Retrieve certificate from Master[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_node_config_dir']}/#{node['fqdn']}.tgz.enc"
-  source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{node['fqdn']}.tgz.enc"
+  source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{node['fqdn']}.tgz.enc"
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt node certificate tgz files]', :immediately
   notifies :run, 'execute[Extract certificate to Node folder]', :immediately

--- a/recipes/ng_node_join.rb
+++ b/recipes/ng_node_join.rb
@@ -18,6 +18,7 @@ end
 remote_file "Retrieve certificate from Master[#{certificate_server['fqdn']}]" do
   path "#{node['cookbook-openshift3']['openshift_node_config_dir']}/#{node['fqdn']}.tgz.enc"
   source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{node['fqdn']}.tgz.enc"
+  headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt node certificate tgz files]', :immediately
   notifies :run, 'execute[Extract certificate to Node folder]', :immediately

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -152,6 +152,7 @@ if is_node_server
   remote_file "Retrieve certificate from Master[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_node_config_dir']}/#{node['fqdn']}.tgz.enc"
     source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{path_certificate}"
+    headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt node certificate tgz files]', :immediately
     notifies :run, 'execute[Extract certificate to Node folder]', :immediately

--- a/recipes/node.rb
+++ b/recipes/node.rb
@@ -12,6 +12,7 @@ pkg_node_to_install = node['cookbook-openshift3']['pkg_node']
 
 ose_major_version = node['cookbook-openshift3']['deploy_containerized'] == true ? node['cookbook-openshift3']['openshift_docker_image_version'] : node['cookbook-openshift3']['ose_major_version']
 path_certificate = node['cookbook-openshift3']['use_wildcard_nodes'] ? 'wildcard_nodes.tgz.enc' : "#{node['fqdn']}.tgz.enc"
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if node['cookbook-openshift3']['encrypted_file_password']['data_bag_name'] && node['cookbook-openshift3']['encrypted_file_password']['data_bag_item_name']
   secret_file = node['cookbook-openshift3']['encrypted_file_password']['secret_file'] || nil
@@ -150,7 +151,7 @@ if is_node_server
 
   remote_file "Retrieve certificate from Master[#{certificate_server['fqdn']}]" do
     path "#{node['cookbook-openshift3']['openshift_node_config_dir']}/#{node['fqdn']}.tgz.enc"
-    source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{path_certificate}"
+    source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/node/generated-configs/#{path_certificate}"
     action :create_if_missing
     notifies :run, 'execute[Un-encrypt node certificate tgz files]', :immediately
     notifies :run, 'execute[Extract certificate to Node folder]', :immediately

--- a/recipes/nodes_certificates.rb
+++ b/recipes/nodes_certificates.rb
@@ -110,4 +110,13 @@ else
       end
     end
   end
+
+  # Add .htaccess for nodes if non-wildcard nodes are used
+  template "#{node['cookbook-openshift3']['openshift_node_generated_configs_dir']}/.htaccess" do
+    owner 'apache'
+    group 'apache'
+    source 'access-htaccess.erb'
+    notifies :run, 'ruby_block[Modify the AllowOverride options]', :immediately
+    variables(servers: node_servers)
+  end
 end

--- a/recipes/wire_aggregator.rb
+++ b/recipes/wire_aggregator.rb
@@ -18,6 +18,7 @@ end
 remote_file 'Retrieve the aggregator certs' do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/wire_aggregator-masters.tgz.enc"
   source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/wire_aggregator-masters.tgz.enc"
+  headers(node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']) if node['cookbook-openshift3']['cert_server_headers'] || node.run_state['openshift3_cert_server_headers']
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt aggregator tgz files]', :immediately
   notifies :run, 'execute[Extract aggregator to Master folder]', :immediately

--- a/recipes/wire_aggregator.rb
+++ b/recipes/wire_aggregator.rb
@@ -6,6 +6,7 @@
 
 server_info = OpenShiftHelper::NodeHelper.new(node)
 certificate_server = server_info.certificate_server
+certificate_server_protocol = server_info.certificate_server_protocol
 
 if node['cookbook-openshift3']['encrypted_file_password']['data_bag_name'] && node['cookbook-openshift3']['encrypted_file_password']['data_bag_item_name']
   secret_file = node['cookbook-openshift3']['encrypted_file_password']['secret_file'] || nil
@@ -16,7 +17,7 @@ end
 
 remote_file 'Retrieve the aggregator certs' do
   path "#{node['cookbook-openshift3']['openshift_master_config_dir']}/wire_aggregator-masters.tgz.enc"
-  source "http://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/wire_aggregator-masters.tgz.enc"
+  source "#{certificate_server_protocol}://#{certificate_server['ipaddress']}:#{node['cookbook-openshift3']['httpd_xfer_port']}/master/generated_certs/wire_aggregator-masters.tgz.enc"
   action :create_if_missing
   notifies :run, 'execute[Un-encrypt aggregator tgz files]', :immediately
   notifies :run, 'execute[Extract aggregator to Master folder]', :immediately


### PR DESCRIPTION
1. Changes added for protocol selection for retrieving certificates from certificate server. By default HTTP will be used.
2. Added possibility to specify headers to remote_file resource for certificate retrieval if custom headers (authentication e.g.) should be sent to certificate server. 
3. Added .htaccess for ca.crt access;
4. Added .htaccess for node certificates;
5. Modified NetworkManager dispatcher script to add nameservers instead of replacing - no impact to existing environments. Default route interface's IP address will be added as the first entry into /etc/resolv.conf unless it's there already.